### PR TITLE
UI restyle: unified theme.css and clean up all pages

### DIFF
--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -88,7 +88,7 @@ export default function Customers() {
   return (
     <div>
       <div className="card">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-2)' }}>
+        <div className="page-header">
           <h2>Customers</h2>
           <Link to="/customers/create" className="button">
             <span className="material-icons" style={{ fontSize: '18px' }}>add</span>
@@ -97,47 +97,23 @@ export default function Customers() {
         </div>
 
         {/* Search and Filters */}
-        <div style={{
-          display: 'flex',
-          gap: 'var(--spacing-2)',
-          marginBottom: 'var(--spacing-2)',
-          flexWrap: 'wrap',
-          alignItems: 'center'
-        }}>
-          <div className="text-field" style={{ minWidth: '300px', flex: 1 }}>
-            <input
-              type="text"
-              value={searchTerm}
-              onChange={e => setSearchTerm(e.target.value)}
-              placeholder="Search customers by name or email..."
-              style={{ width: '100%' }}
-            />
-            <label>Search</label>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--spacing-1)', marginBottom: 'var(--spacing-2)' }}>
+          <div className="text-field">
+            <input type="text" value={searchTerm} onChange={e => setSearchTerm(e.target.value)} placeholder=" " />
+            <label>Search by name or email</label>
           </div>
 
-          <select
-            value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value)}
-            style={{
-              padding: '8px 12px',
-              border: '1px solid var(--outline)',
-              borderRadius: '4px',
-              backgroundColor: 'var(--surface)',
-              color: 'var(--on-surface)',
-              minWidth: '120px'
-            }}
-          >
-            <option value="all">All Statuses</option>
-            <option value="active">Active</option>
-            <option value="archived">Archived</option>
-          </select>
+          <div className="text-field">
+            <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
+              <option value="all">All Statuses</option>
+              <option value="active">Active</option>
+              <option value="archived">Archived</option>
+            </select>
+            <label>Status</label>
+          </div>
 
           {hasActiveFilters && (
-            <button
-              onClick={clearFilters}
-              className="button outlined"
-              style={{ whiteSpace: 'nowrap' }}
-            >
+            <button onClick={clearFilters} className="button button-outline" style={{ alignSelf: 'end', height: '46px' }}>
               <span className="material-icons" style={{ fontSize: '18px' }}>clear</span>
               Clear Filters
             </button>
@@ -221,35 +197,13 @@ export default function Customers() {
 
       {/* Delete Confirmation Modal */}
       {showDeleteConfirm && (
-        <div style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: 'rgba(0, 0, 0, 0.5)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          zIndex: 1000
-        }}>
-          <div className="card" style={{ maxWidth: '400px', margin: 'var(--spacing-2)' }}>
+        <div className="modal-backdrop">
+          <div className="modal-card">
             <h3>Delete Customer</h3>
             <p>Are you sure you want to delete this customer? This action cannot be undone.</p>
-            <div style={{ display: 'flex', gap: 'var(--spacing-1)', justifyContent: 'flex-end', marginTop: 'var(--spacing-2)' }}>
-              <button 
-                className="button outlined" 
-                onClick={() => setShowDeleteConfirm(null)}
-                disabled={loading}
-              >
-                Cancel
-              </button>
-              <button 
-                className="button" 
-                onClick={() => deleteCustomer(showDeleteConfirm)}
-                disabled={loading}
-                style={{ backgroundColor: 'var(--error)', color: 'var(--on-error)' }}
-              >
+            <div className="modal-actions">
+              <button className="button button-outline" onClick={() => setShowDeleteConfirm(null)} disabled={loading}>Cancel</button>
+              <button className="button button-danger" onClick={() => deleteCustomer(showDeleteConfirm)} disabled={loading}>
                 <span className="material-icons" style={{ fontSize: '18px' }}>delete</span>
                 Delete
               </button>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -20,114 +20,43 @@ export default function Dashboard() {
       </div>
       
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 'var(--spacing-3)' }}>
-        <div 
-          className="card" 
-          style={{ cursor: 'pointer', transition: 'transform 0.2s, box-shadow 0.2s' }}
-          onClick={() => handleCardClick('/customers')}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.transform = 'translateY(-2px)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-2)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-1)';
-          }}
-        >
+        <div className="card card-clickable" onClick={() => handleCardClick('/customers')}>
           <div className="card-title">
             <span className="material-icons" style={{ marginRight: '8px', verticalAlign: 'middle' }}>people</span>
             Customers
           </div>
-          <div className="card-content">
-            Manage your customer database and contact information.
-          </div>
+          <div className="card-content">Manage your customer database and contact information.</div>
         </div>
-        
-        <div
-          className="card"
-          style={{ cursor: 'pointer', transition: 'transform 0.2s, box-shadow 0.2s' }}
-          onClick={() => handleCardClick('/carriers')}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.transform = 'translateY(-2px)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-2)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-1)';
-          }}
-        >
+        <div className="card card-clickable" onClick={() => handleCardClick('/carriers')}>
           <div className="card-title">
             <span className="material-icons" style={{ marginRight: '8px', verticalAlign: 'middle' }}>airport_shuttle</span>
             Carriers
           </div>
-          <div className="card-content">
-            Manage carriers and 3PLs with contact and address details.
-          </div>
+          <div className="card-content">Manage carriers and 3PLs with contact and address details.</div>
         </div>
 
-        <div
-          className="card"
-          style={{ cursor: 'pointer', transition: 'transform 0.2s, box-shadow 0.2s' }}
-          onClick={() => handleCardClick('/locations')}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.transform = 'translateY(-2px)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-2)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-1)';
-          }}
-        >
+        <div className="card card-clickable" onClick={() => handleCardClick('/locations')}>
           <div className="card-title">
             <span className="material-icons" style={{ marginRight: '8px', verticalAlign: 'middle' }}>location_on</span>
             Locations
           </div>
-          <div className="card-content">
-            Set up pickup and delivery locations for your shipments.
-          </div>
+          <div className="card-content">Set up pickup and delivery locations for your shipments.</div>
         </div>
-        
-        <div 
-          className="card" 
-          style={{ cursor: 'pointer', transition: 'transform 0.2s, box-shadow 0.2s' }}
-          onClick={() => handleCardClick('/lanes')}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.transform = 'translateY(-2px)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-2)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-1)';
-          }}
-        >
+
+        <div className="card card-clickable" onClick={() => handleCardClick('/lanes')}>
           <div className="card-title">
             <span className="material-icons" style={{ marginRight: '8px', verticalAlign: 'middle' }}>route</span>
             Lanes
           </div>
-          <div className="card-content">
-            Define commercial corridors between locations for customer contracts.
-          </div>
+          <div className="card-content">Define commercial corridors between locations for customer contracts.</div>
         </div>
-        
-        <div 
-          className="card" 
-          style={{ cursor: 'pointer', transition: 'transform 0.2s, box-shadow 0.2s' }}
-          onClick={() => handleCardClick('/shipments')}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.transform = 'translateY(-2px)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-2)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = 'var(--shadow-1)';
-          }}
-        >
+
+        <div className="card card-clickable" onClick={() => handleCardClick('/shipments')}>
           <div className="card-title">
             <span className="material-icons" style={{ marginRight: '8px', verticalAlign: 'middle' }}>local_shipping</span>
             Shipments
           </div>
-          <div className="card-content">
-            Track and manage your transportation shipments.
-          </div>
+          <div className="card-content">Track and manage your transportation shipments.</div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/EditOrder.tsx
+++ b/frontend/src/pages/EditOrder.tsx
@@ -392,7 +392,7 @@ export default function EditOrder() {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-3)' }}>
           <h2>Edit Order</h2>
           <div style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
-            <button onClick={() => navigate(`/orders/${id}`)} className="button button-outlined">
+            <button onClick={() => navigate(`/orders/${id}`)} className="button button-outline">
               Cancel
             </button>
             <button onClick={handleSaveMetadata} disabled={saving} className="button button-primary">
@@ -498,7 +498,7 @@ export default function EditOrder() {
                       Save
                     </button>
                     <button
-                      className="button button-outlined"
+                      className="button button-outline"
                       onClick={() => setEditingUnitId(null)}
                     >
                       Cancel
@@ -520,35 +520,35 @@ export default function EditOrder() {
                     </div>
                     <div style={{ display: 'flex', gap: 'var(--spacing-1)' }}>
                       <button
-                        className="button button-outlined button-small"
+                        className="button button-outline button-sm"
                         onClick={() => setEditingUnitId(unit.id!)}
                         title="Edit Unit"
                       >
                         <span className="material-icons">edit</span>
                       </button>
                       <button
-                        className="button button-outlined button-small"
+                        className="button button-outline button-sm"
                         onClick={() => handleGenerateBarcode(unit.id!)}
                         title="Generate Barcode"
                       >
                         <span className="material-icons">qr_code</span>
                       </button>
                       <button
-                        className="button button-outlined button-small"
+                        className="button button-outline button-sm"
                         onClick={() => handleSplitUnit(unit.id!)}
                         title="Split Unit"
                       >
                         <span className="material-icons">call_split</span>
                       </button>
                       <button
-                        className="button button-outlined button-small"
+                        className="button button-outline button-sm"
                         onClick={() => handleMergeUnits(unit.id!)}
                         title="Merge Unit"
                       >
                         <span className="material-icons">merge</span>
                       </button>
                       <button
-                        className="button button-outlined button-small"
+                        className="button button-outline button-sm"
                         onClick={() => handleRemoveUnit(unit.id!)}
                         style={{ color: 'var(--color-error)' }}
                         title="Delete Unit"
@@ -582,14 +582,14 @@ export default function EditOrder() {
                         <td>
                           <div style={{ display: 'flex', gap: 'var(--spacing-1)' }}>
                             <button
-                              className="button button-outlined button-small"
+                              className="button button-outline button-sm"
                               onClick={() => handleRemoveLineItem(item.id!, unit.id!)}
                               style={{ color: 'var(--color-error)' }}
                             >
                               <span className="material-icons">delete</span>
                             </button>
                             <select
-                              className="button button-outlined button-small"
+                              className="button button-outline button-sm"
                               onChange={(e) => {
                                 if (e.target.value) {
                                   handleMoveItem(item.id!, unit.id!, e.target.value);
@@ -663,7 +663,7 @@ export default function EditOrder() {
                       Add Item
                     </button>
                     <button
-                      className="button button-outlined"
+                      className="button button-outline"
                       onClick={() => setAddingItemToUnit(null)}
                     >
                       Cancel
@@ -672,7 +672,7 @@ export default function EditOrder() {
                 </div>
               ) : (
                 <button
-                  className="button button-outlined"
+                  className="button button-outline"
                   style={{ marginTop: 'var(--spacing-2)' }}
                   onClick={() => setAddingItemToUnit(unit.id!)}
                 >

--- a/frontend/src/pages/Lanes.tsx
+++ b/frontend/src/pages/Lanes.tsx
@@ -195,13 +195,9 @@ export default function Lanes() {
     <div>
       {/* Header with Create Button */}
       <div className="card" style={{ marginBottom: 'var(--spacing-2)' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div className="page-header">
           <h2 style={{ margin: 0 }}>Lanes</h2>
-          <button
-            className="button"
-            onClick={() => navigate('/lanes/create')}
-            disabled={loading}
-          >
+          <button className="button" onClick={() => navigate('/lanes/create')} disabled={loading}>
             <span className="material-icons" style={{ fontSize: '18px' }}>add</span>
             Create New Lane
           </button>
@@ -275,7 +271,7 @@ export default function Lanes() {
           {/* Clear Filters Button */}
           {hasActiveFilters && (
             <button
-              className="button outlined"
+              className="button button-outline"
               onClick={clearFilters}
               disabled={loading}
               title="Clear all filters"
@@ -319,33 +315,10 @@ export default function Lanes() {
         )}
         
         {error && (
-          <div style={{
-            backgroundColor: 'var(--error-container)',
-            color: 'var(--on-error-container)',
-            padding: 'var(--spacing-2)',
-            borderRadius: '4px',
-            marginBottom: 'var(--spacing-2)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--spacing-1)'
-          }}>
+          <div className="alert alert-error">
             <span className="material-icons">error</span>
-            {error}
-            <button 
-              onClick={loadData}
-              style={{ 
-                marginLeft: 'auto',
-                background: 'none',
-                border: 'none',
-                color: 'inherit',
-                cursor: 'pointer',
-                padding: '4px 8px',
-                borderRadius: '4px',
-                backgroundColor: 'rgba(255, 255, 255, 0.1)'
-              }}
-            >
-              Retry
-            </button>
+            <span style={{ flex: 1 }}>{error}</span>
+            <button onClick={loadData} className="button button-sm button-outline" style={{ marginLeft: 'auto' }}>Retry</button>
           </div>
         )}
         
@@ -379,7 +352,7 @@ export default function Lanes() {
                             No lanes match your current filters
                           </div>
                           <button
-                            className="button outlined"
+                            className="button button-outline"
                             onClick={clearFilters}
                             style={{ marginTop: 'var(--spacing-2)' }}
                           >
@@ -520,35 +493,13 @@ export default function Lanes() {
 
       {/* Delete Confirmation Modal */}
       {showDeleteConfirm && (
-        <div style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: 'rgba(0, 0, 0, 0.5)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          zIndex: 1000
-        }}>
-          <div className="card" style={{ maxWidth: '400px', margin: 'var(--spacing-2)' }}>
+        <div className="modal-backdrop">
+          <div className="modal-card">
             <h3>Delete Lane</h3>
             <p>Are you sure you want to delete this lane? This action cannot be undone.</p>
-            <div style={{ display: 'flex', gap: 'var(--spacing-1)', justifyContent: 'flex-end', marginTop: 'var(--spacing-2)' }}>
-              <button 
-                className="button outlined" 
-                onClick={() => setShowDeleteConfirm(null)}
-                disabled={loading}
-              >
-                Cancel
-              </button>
-              <button 
-                className="button" 
-                onClick={() => deleteLane(showDeleteConfirm)}
-                disabled={loading}
-                style={{ backgroundColor: 'var(--error)', color: 'var(--on-error)' }}
-              >
+            <div className="modal-actions">
+              <button className="button button-outline" onClick={() => setShowDeleteConfirm(null)} disabled={loading}>Cancel</button>
+              <button className="button button-danger" onClick={() => deleteLane(showDeleteConfirm)} disabled={loading}>
                 <span className="material-icons" style={{ fontSize: '18px' }}>delete</span>
                 Delete
               </button>

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -113,7 +113,7 @@ export default function Locations() {
   return (
     <div>
       <div className="card">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-2)' }}>
+        <div className="page-header">
           <h2>Locations</h2>
           <Link to="/locations/create" className="button">
             <span className="material-icons" style={{ fontSize: '18px' }}>add</span>
@@ -122,65 +122,33 @@ export default function Locations() {
         </div>
 
         {/* Search and Filters */}
-        <div style={{
-          display: 'flex',
-          gap: 'var(--spacing-2)',
-          marginBottom: 'var(--spacing-2)',
-          flexWrap: 'wrap',
-          alignItems: 'center'
-        }}>
-          <div className="text-field" style={{ minWidth: '300px', flex: 1 }}>
-            <input
-              type="text"
-              value={searchTerm}
-              onChange={e => setSearchTerm(e.target.value)}
-              placeholder="Search locations by name, address, city..."
-              style={{ width: '100%' }}
-            />
-            <label>Search</label>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--spacing-1)', marginBottom: 'var(--spacing-2)' }}>
+          <div className="text-field">
+            <input type="text" value={searchTerm} onChange={e => setSearchTerm(e.target.value)} placeholder=" " />
+            <label>Search by name, address, city</label>
           </div>
 
-          <select
-            value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value)}
-            style={{
-              padding: '8px 12px',
-              border: '1px solid var(--outline)',
-              borderRadius: '4px',
-              backgroundColor: 'var(--surface)',
-              color: 'var(--on-surface)',
-              minWidth: '120px'
-            }}
-          >
-            <option value="all">All Statuses</option>
-            <option value="active">Active</option>
-            <option value="archived">Archived</option>
-          </select>
+          <div className="text-field">
+            <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
+              <option value="all">All Statuses</option>
+              <option value="active">Active</option>
+              <option value="archived">Archived</option>
+            </select>
+            <label>Status</label>
+          </div>
 
-          <select
-            value={countryFilter}
-            onChange={e => setCountryFilter(e.target.value)}
-            style={{
-              padding: '8px 12px',
-              border: '1px solid var(--outline)',
-              borderRadius: '4px',
-              backgroundColor: 'var(--surface)',
-              color: 'var(--on-surface)',
-              minWidth: '120px'
-            }}
-          >
-            <option value="all">All Countries</option>
-            {uniqueCountries.map(country => (
-              <option key={country} value={country}>{country}</option>
-            ))}
-          </select>
+          <div className="text-field">
+            <select value={countryFilter} onChange={e => setCountryFilter(e.target.value)}>
+              <option value="all">All Countries</option>
+              {uniqueCountries.map(country => (
+                <option key={country} value={country}>{country}</option>
+              ))}
+            </select>
+            <label>Country</label>
+          </div>
 
           {hasActiveFilters && (
-            <button
-              onClick={clearFilters}
-              className="button outlined"
-              style={{ whiteSpace: 'nowrap' }}
-            >
+            <button onClick={clearFilters} className="button button-outline" style={{ alignSelf: 'end', height: '46px' }}>
               <span className="material-icons" style={{ fontSize: '18px' }}>clear</span>
               Clear Filters
             </button>
@@ -275,35 +243,13 @@ export default function Locations() {
 
       {/* Delete Confirmation Modal */}
       {showDeleteConfirm && (
-        <div style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: 'rgba(0, 0, 0, 0.5)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          zIndex: 1000
-        }}>
-          <div className="card" style={{ maxWidth: '400px', margin: 'var(--spacing-2)' }}>
+        <div className="modal-backdrop">
+          <div className="modal-card">
             <h3>Delete Location</h3>
             <p>Are you sure you want to delete this location? This action cannot be undone.</p>
-            <div style={{ display: 'flex', gap: 'var(--spacing-1)', justifyContent: 'flex-end', marginTop: 'var(--spacing-2)' }}>
-              <button 
-                className="button outlined" 
-                onClick={() => setShowDeleteConfirm(null)}
-                disabled={loading}
-              >
-                Cancel
-              </button>
-              <button 
-                className="button" 
-                onClick={() => deleteLocation(showDeleteConfirm)}
-                disabled={loading}
-                style={{ backgroundColor: 'var(--error)', color: 'var(--on-error)' }}
-              >
+            <div className="modal-actions">
+              <button className="button button-outline" onClick={() => setShowDeleteConfirm(null)} disabled={loading}>Cancel</button>
+              <button className="button button-danger" onClick={() => deleteLocation(showDeleteConfirm)} disabled={loading}>
                 <span className="material-icons" style={{ fontSize: '18px' }}>delete</span>
                 Delete
               </button>

--- a/frontend/src/pages/OrderDetails.tsx
+++ b/frontend/src/pages/OrderDetails.tsx
@@ -98,24 +98,24 @@ interface Order {
   updatedAt: string;
 }
 
-const statusColors: { [key: string]: string } = {
-  pending: 'var(--color-warning)',
-  validated: 'var(--color-success)',
-  location_error: 'var(--color-error)',
-  converted: 'var(--color-info)',
-  assigned: 'var(--color-success)',
-  pending_lane: 'var(--color-warning)',
-  cancelled: 'var(--color-grey)',
-  archived: 'var(--color-grey)'
+const statusChipClass: { [key: string]: string } = {
+  pending: 'chip chip-warning',
+  validated: 'chip chip-success',
+  location_error: 'chip chip-error',
+  converted: 'chip chip-info',
+  assigned: 'chip chip-success',
+  pending_lane: 'chip chip-warning',
+  cancelled: 'chip chip-primary',
+  archived: 'chip chip-primary'
 };
 
-const deliveryStatusColors: { [key: string]: string } = {
-  unassigned: 'var(--color-grey)',
-  assigned: 'var(--color-info)',
-  in_transit: 'var(--color-primary)',
-  delivered: 'var(--color-success)',
-  exception: 'var(--color-error)',
-  cancelled: 'var(--color-grey)'
+const deliveryStatusChipClass: { [key: string]: string } = {
+  unassigned: 'chip chip-primary',
+  assigned: 'chip chip-info',
+  in_transit: 'chip chip-warning',
+  delivered: 'chip chip-success',
+  exception: 'chip chip-error',
+  cancelled: 'chip chip-primary'
 };
 
 export default function OrderDetails() {
@@ -332,58 +332,28 @@ export default function OrderDetails() {
     }
   };
 
-  const getStatusBadge = (status: string) => {
-    const color = statusColors[status] || 'var(--color-grey)';
-    return (
-      <span
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          padding: '6px 16px',
-          borderRadius: '16px',
-          fontSize: '14px',
-          fontWeight: '500',
-          backgroundColor: `${color}15`,
-          color: color,
-          textTransform: 'capitalize'
-        }}
-      >
-        {status.replace('_', ' ')}
-      </span>
-    );
-  };
+  const getStatusChip = (status: string) => (
+    <span className={statusChipClass[status] || 'chip chip-primary'}>
+      {status.replace(/_/g, ' ')}
+    </span>
+  );
 
-  const getDeliveryStatusBadge = (status: string) => {
-    const color = deliveryStatusColors[status] || 'var(--color-grey)';
-    return (
-      <span
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          padding: '6px 16px',
-          borderRadius: '16px',
-          fontSize: '14px',
-          fontWeight: '500',
-          backgroundColor: `${color}15`,
-          color: color,
-          textTransform: 'capitalize'
-        }}
-      >
-        {status.replace('_', ' ')}
-      </span>
-    );
-  };
+  const getDeliveryStatusChip = (status: string) => (
+    <span className={deliveryStatusChipClass[status] || 'chip chip-primary'}>
+      {status.replace(/_/g, ' ')}
+    </span>
+  );
 
   const getLocationDisplay = (location?: any, locationData?: any, validated?: boolean) => {
     if (location) {
       return (
         <div>
           <div style={{ fontWeight: '500' }}>{location.name}</div>
-          <div style={{ fontSize: '14px', color: 'var(--color-grey)' }}>
+          <div className="text-sm text-muted">
             {location.address1}
             {location.address2 && `, ${location.address2}`}
           </div>
-          <div style={{ fontSize: '14px', color: 'var(--color-grey)' }}>
+          <div className="text-sm text-muted">
             {location.city}, {location.state || location.country} {location.postalCode}
           </div>
         </div>
@@ -391,16 +361,16 @@ export default function OrderDetails() {
     }
     if (locationData && !validated) {
       return (
-        <div style={{ color: 'var(--color-warning)' }}>
+        <div style={{ color: 'var(--warning)' }}>
           <span className="material-icons" style={{ fontSize: '16px', verticalAlign: 'middle' }}>warning</span>
           {' '}Location not validated
-          <div style={{ fontSize: '12px', marginTop: '4px' }}>
+          <div className="text-sm" style={{ marginTop: '4px' }}>
             {locationData.name} - {locationData.city}, {locationData.country}
           </div>
         </div>
       );
     }
-    return <span style={{ color: 'var(--color-grey)' }}>Not specified</span>;
+    return <span className="text-muted">Not specified</span>;
   };
 
   const getTotalItems = () => {
@@ -459,8 +429,8 @@ export default function OrderDetails() {
               </div>
             )}
           </div>
-          <div style={{ display: 'flex', gap: 'var(--spacing-1)', alignItems: 'center' }}>
-            {getStatusBadge(order.status)}
+          <div style={{ display: 'flex', gap: 'var(--spacing-1)', alignItems: 'center', flexWrap: 'wrap' }}>
+            {getStatusChip(order.status)}
             <button
               onClick={handleExportCSV}
               className="button button-sm button-outline no-print"
@@ -506,26 +476,15 @@ export default function OrderDetails() {
             )}
             {showDeleteConfirm ? (
               <>
-                <button
-                  onClick={handleDelete}
-                  className="button button-sm no-print"
-                  style={{ backgroundColor: 'var(--color-error)', color: 'white' }}
-                >
+                <button onClick={handleDelete} className="button button-sm button-danger no-print">
                   Confirm Archive
                 </button>
-                <button
-                  onClick={() => setShowDeleteConfirm(false)}
-                  className="button button-sm button-outline no-print"
-                >
+                <button onClick={() => setShowDeleteConfirm(false)} className="button button-sm button-outline no-print">
                   Cancel
                 </button>
               </>
             ) : (
-              <button
-                onClick={() => setShowDeleteConfirm(true)}
-                className="button button-sm button-outline no-print"
-                style={{ color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
-              >
+              <button onClick={() => setShowDeleteConfirm(true)} className="button button-sm button-outline no-print">
                 <span className="material-icons" style={{ fontSize: '16px' }}>delete</span>
                 Archive
               </button>
@@ -536,7 +495,7 @@ export default function OrderDetails() {
         {/* Order Info Grid */}
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--spacing-2)', marginTop: 'var(--spacing-2)' }}>
           <div>
-            <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Customer</div>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Customer</div>
             <div style={{ fontWeight: '500' }}>{order.customer.name}</div>
             {order.customer.contactEmail && (
               <div style={{ fontSize: '14px', color: 'var(--color-grey)' }}>{order.customer.contactEmail}</div>
@@ -544,25 +503,25 @@ export default function OrderDetails() {
           </div>
 
           <div>
-            <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Import Source</div>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Import Source</div>
             <div style={{ fontWeight: '500', textTransform: 'capitalize' }}>{order.importSource}</div>
           </div>
 
           <div>
-            <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Order Date</div>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Order Date</div>
             <div style={{ fontWeight: '500' }}>{new Date(order.orderDate).toLocaleDateString()}</div>
           </div>
 
           {order.requestedPickupDate && (
             <div>
-              <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Requested Pickup</div>
+              <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Requested Pickup</div>
               <div style={{ fontWeight: '500' }}>{new Date(order.requestedPickupDate).toLocaleDateString()}</div>
             </div>
           )}
 
           {order.requestedDeliveryDate && (
             <div>
-              <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Requested Delivery</div>
+              <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Requested Delivery</div>
               <div style={{ fontWeight: '500' }}>{new Date(order.requestedDeliveryDate).toLocaleDateString()}</div>
             </div>
           )}
@@ -595,33 +554,33 @@ export default function OrderDetails() {
       <div className="card">
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-2)' }}>
           <h3 style={{ margin: 0 }}>Delivery Status</h3>
-          {getDeliveryStatusBadge(order.deliveryStatus)}
+          {getDeliveryStatusChip(order.deliveryStatus)}
         </div>
 
         {/* Status Info Grid */}
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--spacing-2)', marginBottom: 'var(--spacing-2)' }}>
           <div>
-            <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Status</div>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Status</div>
             <div style={{ fontWeight: '500', textTransform: 'capitalize' }}>{order.deliveryStatus.replace('_', ' ')}</div>
           </div>
 
           {order.deliveryMethod && (
             <div>
-              <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Confirmation Method</div>
+              <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Confirmation Method</div>
               <div style={{ fontWeight: '500', textTransform: 'capitalize' }}>{order.deliveryMethod.replace('_', ' ')}</div>
             </div>
           )}
 
           {order.deliveredAt && (
             <div>
-              <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Delivered At</div>
+              <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Delivered At</div>
               <div style={{ fontWeight: '500' }}>{new Date(order.deliveredAt).toLocaleString()}</div>
             </div>
           )}
 
           {order.deliveryConfirmedBy && (
             <div>
-              <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Confirmed By</div>
+              <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Confirmed By</div>
               <div style={{ fontWeight: '500' }}>{order.deliveryConfirmedBy}</div>
             </div>
           )}
@@ -629,67 +588,39 @@ export default function OrderDetails() {
 
         {/* Delivery Stop Info (Multi-leg shipment) */}
         {order.deliveryStop && (
-          <div style={{
-            padding: 'var(--spacing-2)',
-            backgroundColor: 'var(--color-info-light)',
-            border: '1px solid var(--color-info)',
-            borderRadius: '8px',
-            marginBottom: 'var(--spacing-2)'
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-1)', marginBottom: '4px' }}>
-              <span className="material-icons" style={{ color: 'var(--color-info)', fontSize: '18px' }}>flag</span>
-              <strong>Multi-Leg Shipment - Stop #{order.deliveryStop.sequenceNumber}</strong>
-            </div>
-            <div style={{ fontSize: '14px', color: 'var(--color-grey)' }}>
-              Delivery at: {order.deliveryStop.location.name}, {order.deliveryStop.location.city}
-            </div>
-            <div style={{ fontSize: '14px', color: 'var(--color-grey)' }}>
-              Stop Status: <span style={{ textTransform: 'capitalize', fontWeight: '500' }}>{order.deliveryStop.status}</span>
+          <div className="alert alert-info" style={{ marginBottom: 'var(--spacing-2)' }}>
+            <span className="material-icons">flag</span>
+            <div>
+              <strong>Multi-Leg Shipment — Stop #{order.deliveryStop.sequenceNumber}</strong>
+              <div className="text-sm">Delivery at: {order.deliveryStop.location.name}, {order.deliveryStop.location.city}</div>
+              <div className="text-sm">Stop Status: <span style={{ textTransform: 'capitalize', fontWeight: '500' }}>{order.deliveryStop.status}</span></div>
             </div>
           </div>
         )}
 
         {/* Exception Info */}
         {order.deliveryStatus === 'exception' && (
-          <div style={{
-            padding: 'var(--spacing-2)',
-            backgroundColor: 'var(--color-error-light)',
-            border: '1px solid var(--color-error)',
-            borderRadius: '8px',
-            marginBottom: 'var(--spacing-2)'
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-1)', marginBottom: '8px' }}>
-              <span className="material-icons" style={{ color: 'var(--color-error)' }}>warning</span>
+          <div className="alert alert-error" style={{ marginBottom: 'var(--spacing-2)' }}>
+            <span className="material-icons">warning</span>
+            <div>
               <strong>Delivery Exception</strong>
+              {order.exceptionType && (
+                <div className="text-sm">Type: <span style={{ textTransform: 'capitalize', fontWeight: '500' }}>{order.exceptionType.replace(/_/g, ' ')}</span></div>
+              )}
+              {order.exceptionNotes && (
+                <div className="text-sm">Details: {order.exceptionNotes}</div>
+              )}
+              {order.exceptionResolvedAt && (
+                <div className="text-sm">Resolved: {new Date(order.exceptionResolvedAt).toLocaleString()}</div>
+              )}
             </div>
-            {order.exceptionType && (
-              <div style={{ marginBottom: '4px' }}>
-                <strong>Type:</strong> <span style={{ textTransform: 'capitalize' }}>{order.exceptionType.replace('_', ' ')}</span>
-              </div>
-            )}
-            {order.exceptionNotes && (
-              <div style={{ marginBottom: '4px' }}>
-                <strong>Details:</strong> {order.exceptionNotes}
-              </div>
-            )}
-            {order.exceptionResolvedAt && (
-              <div style={{ fontSize: '14px', color: 'var(--color-success)' }}>
-                Resolved: {new Date(order.exceptionResolvedAt).toLocaleString()}
-              </div>
-            )}
           </div>
         )}
 
         {/* Delivery Notes */}
         {order.deliveryNotes && (
-          <div style={{
-            padding: 'var(--spacing-2)',
-            backgroundColor: 'var(--color-surface)',
-            border: '1px solid var(--color-border)',
-            borderRadius: '8px',
-            marginBottom: 'var(--spacing-2)'
-          }}>
-            <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Delivery Notes</div>
+          <div style={{ padding: 'var(--spacing-1) var(--spacing-2)', backgroundColor: 'var(--surface-container)', borderRadius: 'var(--border-radius-sm)', border: '1px solid var(--outline-variant)', marginBottom: 'var(--spacing-2)' }}>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Delivery Notes</div>
             <div style={{ whiteSpace: 'pre-wrap' }}>{order.deliveryNotes}</div>
           </div>
         )}
@@ -718,7 +649,6 @@ export default function OrderDetails() {
                   <button
                     onClick={handleCreateException}
                     className="button button-sm button-outline"
-                    style={{ borderColor: 'var(--color-error)', color: 'var(--color-error)' }}
                   >
                     <span className="material-icons" style={{ fontSize: '16px' }}>warning</span>
                     Report Exception
@@ -728,15 +658,7 @@ export default function OrderDetails() {
             </>
           )}
           {order.deliveryStatus === 'delivered' && (
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--spacing-1)',
-              padding: 'var(--spacing-1)',
-              backgroundColor: 'var(--color-success-light)',
-              borderRadius: '8px',
-              color: 'var(--color-success)'
-            }}>
+            <div className="alert alert-success" style={{ marginBottom: 0 }}>
               <span className="material-icons">check_circle</span>
               <span style={{ fontWeight: '500' }}>Order delivered successfully</span>
             </div>
@@ -747,35 +669,25 @@ export default function OrderDetails() {
       {/* Trackable Units */}
       {order.trackableUnits.length > 0 && (
         <div className="card">
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-2)' }}>
-            <h3 style={{ margin: 0 }}>
-              Trackable Units ({order.trackableUnits.length})
-            </h3>
-            <div style={{ fontSize: '14px', color: 'var(--color-grey)' }}>
-              {getTotalItems()} items total • {getTotalQuantity()} units total
-            </div>
+          <div className="page-header">
+            <h3 style={{ margin: 0 }}>Trackable Units ({order.trackableUnits.length})</h3>
+            <div className="text-sm text-muted">{getTotalItems()} items total • {getTotalQuantity()} units total</div>
           </div>
 
           {order.trackableUnits.map((unit) => (
             <div
               key={unit.id}
-              style={{
-                padding: 'var(--spacing-2)',
-                backgroundColor: 'var(--color-surface)',
-                border: '1px solid var(--color-border)',
-                borderRadius: '8px',
-                marginBottom: 'var(--spacing-2)'
-              }}
+              style={{ padding: 'var(--spacing-2)', backgroundColor: 'var(--surface-container)', border: '1px solid var(--outline-variant)', borderRadius: 'var(--border-radius-sm)', marginBottom: 'var(--spacing-2)' }}
             >
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'start', marginBottom: 'var(--spacing-1)' }}>
                 <div>
                   <h4 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '8px' }}>
-                    <span className="material-icons" style={{ color: 'var(--color-primary)' }}>
+                    <span className="material-icons">
                       {unit.unitType === 'pallet' || unit.unitType === 'tote' ? 'inventory_2' : 'widgets'}
                     </span>
                     {unit.identifier}
                   </h4>
-                  <div style={{ fontSize: '14px', color: 'var(--color-grey)', marginTop: '4px' }}>
+                  <div className="text-sm text-muted" style={{ marginTop: '4px' }}>
                     {unit.customTypeName || unit.unitType.charAt(0).toUpperCase() + unit.unitType.slice(1)}
                     {' • '}
                     {unit.lineItems.length} {unit.lineItems.length === 1 ? 'item' : 'items'}
@@ -783,13 +695,13 @@ export default function OrderDetails() {
                     Sequence #{unit.sequenceNumber}
                   </div>
                   {unit.barcode && (
-                    <div style={{ fontSize: '12px', color: 'var(--color-grey)', marginTop: '4px' }}>
+                    <div className="text-sm text-muted" style={{ marginTop: '4px' }}>
                       <span className="material-icons" style={{ fontSize: '14px', verticalAlign: 'middle' }}>qr_code</span>
                       {' '}{unit.barcode}
                     </div>
                   )}
                   {unit.notes && (
-                    <div style={{ fontSize: '14px', fontStyle: 'italic', color: 'var(--color-grey)', marginTop: '4px' }}>
+                    <div className="text-sm text-muted" style={{ fontStyle: 'italic', marginTop: '4px' }}>
                       {unit.notes}
                     </div>
                   )}
@@ -825,9 +737,9 @@ export default function OrderDetails() {
                         <td style={{ textTransform: 'capitalize' }}>{item.temperature || 'Ambient'}</td>
                         <td>
                           {item.hazmat ? (
-                            <span style={{ color: 'var(--color-error)' }}>⚠️ Yes</span>
+                            <span className="chip chip-error">⚠ Yes</span>
                           ) : (
-                            <span style={{ color: 'var(--color-grey)' }}>No</span>
+                            <span className="text-muted">No</span>
                           )}
                         </td>
                       </tr>
@@ -843,17 +755,9 @@ export default function OrderDetails() {
       {/* Legacy Line Items (if any) */}
       {order.lineItems.length > 0 && (
         <div className="card">
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: 'var(--spacing-2)' }}>
+          <div className="page-header">
             <h3 style={{ margin: 0 }}>Line Items (Legacy)</h3>
-            <span style={{
-              fontSize: '12px',
-              padding: '4px 8px',
-              borderRadius: '4px',
-              backgroundColor: 'var(--color-warning-bg)',
-              color: 'var(--color-warning)'
-            }}>
-              Not in trackable units
-            </span>
+            <span className="chip chip-warning">Not in trackable units</span>
           </div>
 
           <div style={{ overflowX: 'auto' }}>
@@ -903,20 +807,20 @@ export default function OrderDetails() {
           <h3>Additional Information</h3>
           {order.specialInstructions && (
             <div style={{ marginBottom: 'var(--spacing-2)' }}>
-              <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>
+              <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>
                 Special Instructions
               </div>
-              <div style={{ padding: 'var(--spacing-1)', backgroundColor: 'var(--color-surface)', borderRadius: '4px' }}>
+              <div style={{ padding: 'var(--spacing-1)', backgroundColor: 'var(--surface-container)', borderRadius: 'var(--border-radius-sm)' }}>
                 {order.specialInstructions}
               </div>
             </div>
           )}
           {order.notes && (
             <div>
-              <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>
+              <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>
                 Notes
               </div>
-              <div style={{ padding: 'var(--spacing-1)', backgroundColor: 'var(--color-surface)', borderRadius: '4px' }}>
+              <div style={{ padding: 'var(--spacing-1)', backgroundColor: 'var(--surface-container)', borderRadius: 'var(--border-radius-sm)' }}>
                 {order.notes}
               </div>
             </div>
@@ -929,15 +833,15 @@ export default function OrderDetails() {
         <h3>Metadata</h3>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--spacing-2)' }}>
           <div>
-            <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Created</div>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Created</div>
             <div>{new Date(order.createdAt).toLocaleString()}</div>
           </div>
           <div>
-            <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Last Updated</div>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Last Updated</div>
             <div>{new Date(order.updatedAt).toLocaleString()}</div>
           </div>
           <div>
-            <div style={{ fontSize: '12px', color: 'var(--color-grey)', textTransform: 'uppercase', marginBottom: '4px' }}>Order ID</div>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '4px', color: 'var(--on-surface-variant)' }}>Order ID</div>
             <div style={{ fontSize: '12px', fontFamily: 'monospace' }}>{order.id}</div>
           </div>
         </div>

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -58,13 +58,13 @@ interface Order {
   updatedAt: string;
 }
 
-const statusColors: { [key: string]: string } = {
-  pending: 'var(--color-warning)',
-  validated: 'var(--color-success)',
-  location_error: 'var(--color-error)',
-  converted: 'var(--color-info)',
-  cancelled: 'var(--color-grey)',
-  archived: 'var(--color-grey)'
+const statusChipClass: { [key: string]: string } = {
+  pending: 'chip chip-warning',
+  validated: 'chip chip-success',
+  location_error: 'chip chip-error',
+  converted: 'chip chip-info',
+  cancelled: 'chip chip-primary',
+  archived: 'chip chip-primary'
 };
 
 export default function Orders() {
@@ -144,26 +144,11 @@ export default function Orders() {
     }
   };
 
-  const getStatusBadge = (status: string) => {
-    const color = statusColors[status] || 'var(--color-grey)';
-    return (
-      <span
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          padding: '4px 12px',
-          borderRadius: '12px',
-          fontSize: '12px',
-          fontWeight: '500',
-          backgroundColor: `${color}15`,
-          color: color,
-          textTransform: 'capitalize'
-        }}
-      >
-        {status.replace('_', ' ')}
-      </span>
-    );
-  };
+  const getStatusChip = (status: string) => (
+    <span className={statusChipClass[status] || 'chip chip-primary'}>
+      {status.replace(/_/g, ' ')}
+    </span>
+  );
 
   const getLocationDisplay = (location?: any, locationData?: any, validated?: boolean) => {
     if (location) {
@@ -171,19 +156,19 @@ export default function Orders() {
     }
     if (locationData && !validated) {
       return (
-        <span style={{ color: 'var(--color-warning)' }}>
+        <span style={{ color: 'var(--warning)' }}>
           <span className="material-icons" style={{ fontSize: '14px', verticalAlign: 'middle' }}>warning</span>
           {' '}Not validated
         </span>
       );
     }
-    return <span style={{ color: 'var(--color-grey)' }}>Not specified</span>;
+    return <span className="text-muted">Not specified</span>;
   };
 
   return (
     <div>
       <div className="card">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-2)' }}>
+        <div className="page-header">
           <h2>Orders</h2>
           <div style={{ display: 'flex', gap: 'var(--spacing-1)' }}>
             <Link to="/orders/create" className="button">
@@ -254,8 +239,8 @@ export default function Orders() {
 
         {loading && (
           <div style={{ textAlign: 'center', padding: 'var(--spacing-4)' }}>
-            <div className="loading-spinner"></div>
-            <p>Loading orders...</p>
+            <div className="loading-spinner" style={{ margin: '0 auto var(--spacing-1)' }}></div>
+            <p className="text-muted">Loading orders...</p>
           </div>
         )}
 
@@ -269,7 +254,7 @@ export default function Orders() {
         )}
 
         {!loading && filteredOrders.length > 0 && (
-          <div style={{ overflowX: 'auto' }}>
+          <div className="table-container" style={{ overflowX: 'auto' }}>
             <table className="data-table">
               <thead>
                 <tr>
@@ -288,11 +273,11 @@ export default function Orders() {
                 {filteredOrders.map((order) => (
                   <tr key={order.id}>
                     <td>
-                      <Link to={`/orders/${order.id}`} style={{ fontWeight: '500', color: 'var(--color-primary)' }}>
+                      <Link to={`/orders/${order.id}`} style={{ fontWeight: '500' }}>
                         {order.orderNumber}
                       </Link>
                       {order.poNumber && (
-                        <div style={{ fontSize: '12px', color: 'var(--color-grey)' }}>
+                        <div className="text-sm text-muted">
                           PO: {order.poNumber}
                         </div>
                       )}
@@ -304,7 +289,7 @@ export default function Orders() {
                     <td style={{ fontSize: '14px' }}>
                       {getLocationDisplay(order.destination, order.destinationData, order.destinationValidated)}
                     </td>
-                    <td>{getStatusBadge(order.status)}</td>
+                    <td>{getStatusChip(order.status)}</td>
                     <td style={{ textTransform: 'capitalize' }}>{order.importSource}</td>
                     <td style={{ textAlign: 'center' }}>
                       {order.trackableUnits.length > 0 ? (
@@ -312,14 +297,14 @@ export default function Orders() {
                           <div style={{ fontWeight: '500' }}>
                             {order.trackableUnits.length} {order.trackableUnits.length === 1 ? 'unit' : 'units'}
                           </div>
-                          <div style={{ fontSize: '12px', color: 'var(--color-grey)' }}>
+                          <div className="text-sm text-muted">
                             {order.trackableUnits.reduce((total, unit) => total + unit.lineItems.length, 0)} items
                           </div>
                         </div>
                       ) : order.lineItems.length > 0 ? (
                         <span>{order.lineItems.length} items (legacy)</span>
                       ) : (
-                        <span style={{ color: 'var(--color-grey)' }}>—</span>
+                        <span className="text-muted">—</span>
                       )}
                     </td>
                     <td>{new Date(order.orderDate).toLocaleDateString()}</td>
@@ -336,8 +321,7 @@ export default function Orders() {
                           <>
                             <button
                               onClick={() => deleteOrder(order.id)}
-                              className="button button-sm"
-                              style={{ backgroundColor: 'var(--color-error)', color: 'white' }}
+                              className="button button-sm button-danger"
                             >
                               Confirm
                             </button>
@@ -353,7 +337,6 @@ export default function Orders() {
                             onClick={() => setShowDeleteConfirm(order.id)}
                             className="button button-sm button-outline"
                             title="Archive Order"
-                            style={{ color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
                           >
                             <span className="material-icons" style={{ fontSize: '16px' }}>delete</span>
                           </button>

--- a/frontend/src/pages/PendingLaneRequests.tsx
+++ b/frontend/src/pages/PendingLaneRequests.tsx
@@ -286,7 +286,7 @@ export default function PendingLaneRequests() {
                           <>
                             <button
                               onClick={() => handleCreateLane(request)}
-                              className="button button-small button-primary"
+                              className="button button-sm"
                               style={{ fontSize: '12px', padding: '4px 8px' }}
                             >
                               <span className="material-icons" style={{ fontSize: '14px' }}>add</span>
@@ -294,7 +294,7 @@ export default function PendingLaneRequests() {
                             </button>
                             <button
                               onClick={() => handleApprove(request.id)}
-                              className="button button-small button-outlined"
+                              className="button button-sm button-outline"
                               style={{ fontSize: '12px', padding: '4px 8px' }}
                             >
                               <span className="material-icons" style={{ fontSize: '14px' }}>check</span>
@@ -302,7 +302,7 @@ export default function PendingLaneRequests() {
                             </button>
                             <button
                               onClick={() => handleReject(request.id)}
-                              className="button button-small button-outlined"
+                              className="button button-sm button-outline"
                               style={{ fontSize: '12px', padding: '4px 8px', color: 'var(--color-error)' }}
                             >
                               <span className="material-icons" style={{ fontSize: '14px' }}>close</span>
@@ -313,7 +313,7 @@ export default function PendingLaneRequests() {
                         {request.status === 'approved' && (
                           <button
                             onClick={() => handleCreateLane(request)}
-                            className="button button-small button-primary"
+                            className="button button-sm"
                             style={{ fontSize: '12px', padding: '4px 8px' }}
                           >
                             <span className="material-icons" style={{ fontSize: '14px' }}>add</span>
@@ -323,7 +323,7 @@ export default function PendingLaneRequests() {
                         {request.status === 'lane_created' && request.createdLaneId && (
                           <Link
                             to={`/lanes/${request.createdLaneId}/edit`}
-                            className="button button-small button-outlined"
+                            className="button button-sm button-outline"
                             style={{ fontSize: '12px', padding: '4px 8px', textDecoration: 'none' }}
                           >
                             <span className="material-icons" style={{ fontSize: '14px' }}>visibility</span>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -139,7 +139,7 @@ export default function Settings() {
     <div>
       <div className="card">
         <h2>Organization Settings</h2>
-        <p style={{ color: 'var(--color-grey)', marginBottom: 'var(--spacing-3)' }}>
+        <p className="text-muted" style={{ marginBottom: 'var(--spacing-3)' }}>
           Configure how your organization tracks inventory within orders
         </p>
 
@@ -258,26 +258,15 @@ export default function Settings() {
 
             <h3 style={{ gridColumn: '1 / -1', marginTop: 'var(--spacing-3)' }}>Unit of Measure</h3>
 
-            <div style={{
-              gridColumn: '1 / -1',
-              padding: 'var(--spacing-2)',
-              backgroundColor: 'var(--color-surface-variant)',
-              borderRadius: '8px',
-              marginBottom: 'var(--spacing-2)'
-            }}>
-              <p style={{ color: 'var(--color-grey)', fontSize: '14px', margin: 0 }}>
+            <div style={{ gridColumn: '1 / -1', padding: 'var(--spacing-2)', backgroundColor: 'var(--surface-container)', borderRadius: 'var(--border-radius-sm)', marginBottom: 'var(--spacing-2)' }}>
+              <p className="text-muted" style={{ fontSize: '0.9375rem', margin: 0 }}>
                 These settings define the default units used when entering weight and dimensions for line items in orders.
                 Users can override these defaults on individual items if needed.
               </p>
             </div>
 
             <div className="input-wrapper" style={{ gridColumn: '1 / -1' }}>
-              <select
-                value={weightUnit}
-                onChange={(e) => setWeightUnit(e.target.value as 'kg' | 'lb')}
-                className="input"
-                required
-              >
+              <select value={weightUnit} onChange={(e) => setWeightUnit(e.target.value as 'kg' | 'lb')} className="input" required>
                 <option value="kg">Kilograms (kg)</option>
                 <option value="lb">Pounds (lb)</option>
               </select>
@@ -285,35 +274,22 @@ export default function Settings() {
             </div>
 
             <div className="input-wrapper" style={{ gridColumn: '1 / -1' }}>
-              <select
-                value={dimUnit}
-                onChange={(e) => setDimUnit(e.target.value as 'cm' | 'in')}
-                className="input"
-                required
-              >
+              <select value={dimUnit} onChange={(e) => setDimUnit(e.target.value as 'cm' | 'in')} className="input" required>
                 <option value="cm">Centimeters (cm)</option>
                 <option value="in">Inches (in)</option>
               </select>
               <label>Default Dimension Unit</label>
             </div>
 
-            <div style={{
-              gridColumn: '1 / -1',
-              padding: 'var(--spacing-2)',
-              backgroundColor: 'var(--color-warning-bg)',
-              borderLeft: '4px solid var(--color-warning)',
-              borderRadius: '4px'
-            }}>
-              <div style={{ display: 'flex', alignItems: 'start', gap: 'var(--spacing-1)' }}>
-                <span className="material-icons" style={{ color: 'var(--color-warning)' }}>warning</span>
-                <div>
-                  <strong>Important:</strong> Changing these settings will affect how new orders are created.
-                  Existing orders will retain their current unit configuration.
-                </div>
+            <div className="alert alert-warning" style={{ gridColumn: '1 / -1' }}>
+              <span className="material-icons">warning</span>
+              <div>
+                <strong>Important:</strong> Changing these settings will affect how new orders are created.
+                Existing orders will retain their current unit configuration.
               </div>
             </div>
 
-            <div style={{ gridColumn: '1 / -1', display: 'flex', gap: 'var(--spacing-1)', justifyContent: 'flex-end', marginTop: 'var(--spacing-2)' }}>
+            <div className="form-actions" style={{ gridColumn: '1 / -1' }}>
               <button type="button" onClick={loadSettings} className="button button-outline" disabled={saving}>
                 Reset
               </button>
@@ -332,13 +308,13 @@ export default function Settings() {
           <div style={{ display: 'grid', gap: 'var(--spacing-2)' }}>
             <div>
               <strong>Tracking Mode:</strong>{' '}
-              <span style={{ color: 'var(--color-primary)' }}>
+              <span className="chip chip-primary" style={{ marginLeft: '4px' }}>
                 {trackingMode === 'group' ? 'Group Level' : 'Item Level'}
               </span>
             </div>
             <div>
               <strong>Trackable Unit Type:</strong>{' '}
-              <span style={{ color: 'var(--color-primary)' }}>
+              <span className="chip chip-primary" style={{ marginLeft: '4px' }}>
                 {trackableUnitType === 'custom'
                   ? customUnitName || 'Custom (not specified)'
                   : trackableUnitType.charAt(0).toUpperCase() + trackableUnitType.slice(1)
@@ -347,22 +323,17 @@ export default function Settings() {
             </div>
             <div>
               <strong>Default Weight Unit:</strong>{' '}
-              <span style={{ color: 'var(--color-primary)' }}>
+              <span className="chip chip-primary" style={{ marginLeft: '4px' }}>
                 {weightUnit === 'kg' ? 'Kilograms (kg)' : 'Pounds (lb)'}
               </span>
             </div>
             <div>
               <strong>Default Dimension Unit:</strong>{' '}
-              <span style={{ color: 'var(--color-primary)' }}>
+              <span className="chip chip-primary" style={{ marginLeft: '4px' }}>
                 {dimUnit === 'cm' ? 'Centimeters (cm)' : 'Inches (in)'}
               </span>
             </div>
-            <div style={{
-              padding: 'var(--spacing-2)',
-              backgroundColor: 'var(--color-surface)',
-              borderRadius: '4px',
-              fontSize: '14px'
-            }}>
+            <div style={{ padding: 'var(--spacing-2)', backgroundColor: 'var(--surface-container)', borderRadius: 'var(--border-radius-sm)', fontSize: '0.9375rem' }}>
               <strong>This means:</strong> When creating orders, users will add one or more{' '}
               <strong>
                 {trackableUnitType === 'custom'

--- a/frontend/src/pages/Shipments.tsx
+++ b/frontend/src/pages/Shipments.tsx
@@ -140,7 +140,7 @@ export default function Shipments() {
   return (
     <div>
       <div className="card">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-2)' }}>
+        <div className="page-header">
           <h2>Shipments</h2>
           <Link to="/shipments/create" className="button">
             <span className="material-icons" style={{ fontSize: '18px' }}>add</span>
@@ -149,68 +149,41 @@ export default function Shipments() {
         </div>
 
         {/* Search and Filters */}
-        <div style={{
-          display: 'flex',
-          gap: 'var(--spacing-2)',
-          marginBottom: 'var(--spacing-2)',
-          flexWrap: 'wrap',
-          alignItems: 'center'
-        }}>
-          <div className="text-field" style={{ minWidth: '300px', flex: 1 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--spacing-1)', marginBottom: 'var(--spacing-2)' }}>
+          <div className="text-field">
             <input
               type="text"
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}
-              placeholder="Search by reference, customer, origin, destination..."
-              style={{ width: '100%' }}
+              placeholder=" "
             />
-            <label>Search</label>
+            <label>Search by reference, customer, lane…</label>
           </div>
 
-          <select
-            value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value)}
-            style={{
-              padding: '8px 12px',
-              border: '1px solid var(--outline)',
-              borderRadius: '4px',
-              backgroundColor: 'var(--surface)',
-              color: 'var(--on-surface)',
-              minWidth: '120px'
-            }}
-          >
-            <option value="all">All Statuses</option>
-            {uniqueStatuses.map(status => (
-              <option key={status} value={status}>
-                {status.charAt(0).toUpperCase() + status.slice(1).replace('_', ' ')}
-              </option>
-            ))}
-          </select>
+          <div className="text-field">
+            <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
+              <option value="all">All Statuses</option>
+              {uniqueStatuses.map(status => (
+                <option key={status} value={status}>
+                  {status.charAt(0).toUpperCase() + status.slice(1).replace('_', ' ')}
+                </option>
+              ))}
+            </select>
+            <label>Status</label>
+          </div>
 
-          <select
-            value={customerFilter}
-            onChange={e => setCustomerFilter(e.target.value)}
-            style={{
-              padding: '8px 12px',
-              border: '1px solid var(--outline)',
-              borderRadius: '4px',
-              backgroundColor: 'var(--surface)',
-              color: 'var(--on-surface)',
-              minWidth: '150px'
-            }}
-          >
-            <option value="all">All Customers</option>
-            {uniqueCustomers.map(customer => (
-              <option key={customer.id} value={customer.id}>{customer.name}</option>
-            ))}
-          </select>
+          <div className="text-field">
+            <select value={customerFilter} onChange={e => setCustomerFilter(e.target.value)}>
+              <option value="all">All Customers</option>
+              {uniqueCustomers.map(customer => (
+                <option key={customer.id} value={customer.id}>{customer.name}</option>
+              ))}
+            </select>
+            <label>Customer</label>
+          </div>
 
           {hasActiveFilters && (
-            <button
-              onClick={clearFilters}
-              className="button outlined"
-              style={{ whiteSpace: 'nowrap' }}
-            >
+            <button onClick={clearFilters} className="button button-outline" style={{ alignSelf: 'end', height: '46px' }}>
               <span className="material-icons" style={{ fontSize: '18px' }}>clear</span>
               Clear Filters
             </button>
@@ -354,35 +327,15 @@ export default function Shipments() {
 
       {/* Delete Confirmation Modal */}
       {showDeleteConfirm && (
-        <div style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: 'rgba(0, 0, 0, 0.5)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          zIndex: 1000
-        }}>
-          <div className="card" style={{ maxWidth: '400px', margin: 'var(--spacing-2)' }}>
+        <div className="modal-backdrop">
+          <div className="modal-card">
             <h3>Delete Shipment</h3>
             <p>Are you sure you want to delete this shipment? This action cannot be undone.</p>
-            <div style={{ display: 'flex', gap: 'var(--spacing-1)', justifyContent: 'flex-end', marginTop: 'var(--spacing-2)' }}>
-              <button 
-                className="button outlined" 
-                onClick={() => setShowDeleteConfirm(null)}
-                disabled={loading}
-              >
+            <div className="modal-actions">
+              <button className="button button-outline" onClick={() => setShowDeleteConfirm(null)} disabled={loading}>
                 Cancel
               </button>
-              <button 
-                className="button" 
-                onClick={() => deleteShipment(showDeleteConfirm)}
-                disabled={loading}
-                style={{ backgroundColor: 'var(--error)', color: 'var(--on-error)' }}
-              >
+              <button className="button button-danger" onClick={() => deleteShipment(showDeleteConfirm)} disabled={loading}>
                 <span className="material-icons" style={{ fontSize: '18px' }}>delete</span>
                 Delete
               </button>

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -1,6 +1,26 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap');
 @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 
+/* ============================================================
+   CANONICAL CLASS REFERENCE
+   ============================================================
+   Layout:       .card, .page-header
+   Buttons:      .button | .button.small/.button-sm | .button-outline
+                 .button-success | .button-danger | .icon-btn
+   Forms:        .text-field | .text-field.field-error | .field-hint
+                 .input-wrapper (alias of .text-field)
+                 .check-field (checkbox/radio)
+                 .form-grid | .col-span-2
+                 .form-section + .form-section-title
+                 .form-actions
+   Tables:       .data-table (alias of .table) inside .table-container
+   Status:       .chip .chip-{success|warning|error|info|primary|secondary}
+                 .chip-outline
+   Feedback:     .alert .alert-{error|success|info|warning}
+                 .loading-spinner
+   Modal:        .modal-backdrop > .modal-card
+   ============================================================ */
+
 :root {
   /* Light Theme Colors */
   --primary: #000000;
@@ -46,22 +66,49 @@
   --outline-variant: #BFC8CA;
   --shadow: #000000;
   --neutral-variant: #565656;
-  
+
   /* Spacing */
   --spacing-1: 8px;
   --spacing-2: 16px;
   --spacing-3: 24px;
   --spacing-4: 32px;
-  
+
   /* Border Radius */
   --border-radius-sm: 8px;
   --border-radius-md: 16px;
   --border-radius-lg: 24px;
   --border-radius-full: 30px;
-  
+
   /* Shadows */
   --shadow-1: 0px 1px 2px rgba(0, 0, 0, 0.3), 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
   --shadow-2: 0px 1px 2px rgba(0, 0, 0, 0.3), 0px 2px 6px 2px rgba(0, 0, 0, 0.15);
+
+  /* ── Alias variables ──────────────────────────────────────
+     Maps the names components use → canonical token names.
+     Fixes ~22 broken CSS variable references with zero component changes. */
+  --color-primary:            var(--primary);
+  --color-error:              var(--error);
+  --color-error-light:        var(--error-container);
+  --color-error-container:    var(--error-container);
+  --color-success:            var(--success);
+  --color-success-light:      var(--success-container);
+  --color-success-bg:         var(--success-container);
+  --color-warning:            var(--warning);
+  --color-warning-light:      var(--warning-container);
+  --color-warning-bg:         var(--warning-container);
+  --color-info:               var(--info);
+  --color-info-light:         var(--info-container);
+  --color-grey:               var(--on-surface-variant);
+  --color-border:             var(--outline-variant);
+  --color-surface:            var(--surface-container-low);
+  --color-surface-variant:    var(--surface-variant);
+  --color-outline:            var(--outline);
+  --color-on-error-container: var(--on-error-container);
+  --color-primary-bg:         var(--primary-container);
+  /* Border radius aliases */
+  --border-radius:            var(--border-radius-sm);
+  --radius-medium:            var(--border-radius-md);
+  --radius-large:             var(--border-radius-lg);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -125,7 +172,9 @@ body {
   padding: 0;
 }
 
-/* App Bar */
+/* ============================================================
+   APP BAR
+   ============================================================ */
 .app-bar {
   background-color: var(--surface-container-lowest);
   color: var(--on-surface);
@@ -165,14 +214,15 @@ body {
   display: none;
 }
 
-/* Hide hamburger menu when sidebar is visible (desktop) */
 @media (min-width: 769px) {
   .mobile-menu-btn {
     display: none !important;
   }
 }
 
-/* Sidebar */
+/* ============================================================
+   SIDEBAR
+   ============================================================ */
 .sidebar {
   background-color: var(--surface-container);
   width: 280px;
@@ -207,7 +257,7 @@ body {
   display: flex;
   align-items: center;
   padding: 12px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--border-radius-sm);
   color: var(--on-surface);
   text-decoration: none;
   transition: background-color 0.2s;
@@ -228,7 +278,9 @@ body {
   font-size: 18px;
 }
 
-/* Mobile Overlay */
+/* ============================================================
+   MOBILE OVERLAY
+   ============================================================ */
 .mobile-overlay {
   position: fixed;
   top: 0;
@@ -240,17 +292,38 @@ body {
   display: none;
 }
 
-/* Main Layout */
+/* ============================================================
+   MAIN LAYOUT
+   ============================================================ */
 .main {
   margin-left: 280px;
   padding: var(--spacing-3);
   min-height: 100vh;
 }
 
-/* Cards */
+/* ============================================================
+   PAGE HEADER
+   ============================================================ */
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.page-header h1,
+.page-header h2 {
+  margin: 0;
+}
+
+/* ============================================================
+   CARDS
+   ============================================================ */
 .card {
   background-color: var(--surface-container-low);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--border-radius-sm);
   padding: var(--spacing-3);
   box-shadow: none;
   margin-bottom: var(--spacing-2);
@@ -261,8 +334,18 @@ body {
   box-shadow: var(--shadow-1);
 }
 
+.card-clickable {
+  cursor: pointer;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.card-clickable:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-2);
+}
+
 .card-title {
-  font-size: 1.25rem;
+  font-size: 1.125rem;
   font-weight: 500;
   margin-bottom: var(--spacing-1);
   color: var(--on-surface);
@@ -273,7 +356,9 @@ body {
   line-height: 1.4;
 }
 
-/* Buttons */
+/* ============================================================
+   BUTTONS
+   ============================================================ */
 .button {
   display: inline-flex;
   align-items: center;
@@ -293,21 +378,53 @@ body {
   background-color: var(--primary);
   color: var(--on-primary);
   box-shadow: none;
+  white-space: nowrap;
 }
 
 .button:hover {
   box-shadow: var(--shadow-1);
 }
 
+.button:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+/* Size variants */
+.button.small,
+.button-sm,
+.button-small {
+  min-height: 28px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+}
+
+.button.large {
+  min-height: 40px;
+  padding: 10px 20px;
+  font-size: 1rem;
+}
+
+/* Style variants */
 .button.tonal {
   background-color: var(--secondary-container);
   color: var(--on-secondary-container);
 }
 
-.button.outlined {
+.button.outlined,
+.button-outline,
+.button-outlined {
   background-color: transparent;
-  color: var(--primary);
-  border: 1px solid var(--outline);
+  color: var(--on-surface);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--border-radius-sm);
+}
+
+.button.outlined:hover,
+.button-outline:hover,
+.button-outlined:hover {
+  background-color: var(--surface-variant);
+  box-shadow: none;
 }
 
 .button.text {
@@ -326,272 +443,39 @@ body {
   box-shadow: var(--shadow-2);
 }
 
-.button.small {
-  min-height: 32px;
-  padding: 6px 12px;
-  font-size: 0.75rem;
+/* Semantic colour variants */
+.button-primary {
+  background-color: var(--primary);
+  color: var(--on-primary);
+  border: none;
+  border-radius: var(--border-radius-full);
 }
 
-.button.large {
-  min-height: 40px;
-  padding: 10px 20px;
-  font-size: 1rem;
+.button-success {
+  background-color: var(--success);
+  color: var(--on-success);
+  border: none;
+  border-radius: var(--border-radius-full);
 }
 
-.button:disabled {
-  opacity: 0.38;
-  cursor: not-allowed;
+.button-success:hover {
+  box-shadow: var(--shadow-1);
 }
 
-/* Form Elements */
-input, select {
-  width: 100%;
-  padding: 16px 12px 8px 12px;
-  border: 1px solid var(--outline-variant);
-  border-radius: 4px;
-  background-color: transparent;
-  color: var(--on-surface);
-  font-family: 'Roboto', sans-serif;
-  font-size: 1rem;
-  outline: none;
-  transition: border-color 0.2s;
-  margin-bottom: var(--spacing-2);
+.button-danger {
+  background-color: var(--error);
+  color: var(--on-error);
+  border: none;
+  border-radius: var(--border-radius-full);
 }
 
-input:focus, select:focus {
-  border-color: var(--primary);
+.button-danger:hover {
+  box-shadow: var(--shadow-1);
 }
 
-input:not(:placeholder-shown) {
-  padding-top: 16px;
-  padding-bottom: 8px;
-}
-
-input::placeholder {
-  color: transparent;
-}
-
-/* Text Field with Label */
-.text-field {
-  position: relative;
-  margin-bottom: var(--spacing-2);
-  width: 100%;
-}
-
-.text-field input,
-.text-field select {
-  width: 100%;
-  padding: 16px 12px 8px 12px;
-  border: 1px solid var(--outline-variant);
-  border-radius: 4px;
-  background-color: transparent;
-  color: var(--on-surface);
-  font-family: 'Roboto', sans-serif;
-  font-size: 1rem;
-  outline: none;
-  transition: border-color 0.2s;
-}
-
-.text-field select {
-  padding: 16px 40px 8px 12px;
-}
-
-.text-field input:focus,
-.text-field select:focus {
-  border-color: var(--primary);
-}
-
-.text-field label {
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--on-surface-variant);
-  font-size: 0.75rem;
-  font-weight: 400;
-  pointer-events: none;
-  transition: all 0.2s;
-  background-color: var(--background);
-  padding: 0 4px;
-  z-index: 1;
-}
-
-.text-field input:focus + label,
-.text-field input:not(:placeholder-shown) + label,
-.text-field select:focus + label,
-.text-field select:not([value=""]) + label,
-.text-field select:valid + label {
-  top: 0;
-  transform: translateY(-50%);
-  color: var(--primary);
-  font-size: 0.75rem;
-}
-
-/* Ensure label is always positioned correctly for selects */
-.text-field select + label {
-  top: 0;
-  left: 12px;
-  transform: translateY(-50%);
-  color: var(--primary);
-  font-size: 0.75rem;
-  pointer-events: none;
-  z-index: 1;
-  background-color: var(--background);
-  padding: 0 4px;
-}
-
-/* Special handling for select elements */
-.text-field select {
-  appearance: none;
-  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
-  background-repeat: no-repeat;
-  background-position: right 12px center;
-  background-size: 16px;
-  cursor: pointer;
-}
-
-.text-field select:invalid {
-  color: var(--on-surface-variant);
-}
-
-.text-field select:valid {
-  color: var(--on-surface);
-}
-
-.text-field select option {
-  color: var(--on-surface);
-  background-color: var(--surface);
-  padding: 8px;
-}
-
-.text-field select option:first-child {
-  color: var(--on-surface-variant);
-}
-
-/* Tables */
-.table-container {
-  background-color: var(--surface-container-low);
-  border-radius: var(--border-radius-md);
-  overflow: hidden;
-  box-shadow: none;
-  border: 1px solid var(--outline-variant);
-}
-
-.table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.table th {
-  background-color: var(--surface);
-  padding: 8px 12px;
-  text-align: left;
-  font-weight: 500;
-  font-size: 0.875rem;
-  color: var(--on-surface);
-  border-bottom: 1px solid var(--outline-variant);
-  border-right: 1px solid var(--outline-variant);
-}
-
-.table th:last-child {
-  border-right: none;
-}
-
-.table td {
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--outline-variant);
-  border-right: 1px solid var(--outline-variant);
-  color: var(--on-surface);
-}
-
-.table td:last-child {
-  border-right: none;
-}
-
-.table tr:hover {
-  background-color: var(--surface-variant);
-}
-
-.table tr:last-child td {
-  border-bottom: none;
-}
-
-/* Chips */
-.chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 12px;
-  border-radius: var(--border-radius-sm);
-  font-size: 0.75rem;
-  font-weight: 500;
-  gap: 8px;
-  margin: 2px;
-}
-
-.chip-primary {
-  background-color: rgba(63, 72, 74, 0.08);
-  color: var(--primary);
-}
-
-.chip-secondary {
-  background-color: var(--secondary-container);
-  color: var(--on-secondary-container);
-}
-
-.chip-success {
-  background-color: var(--success-container);
-  color: var(--on-success-container);
-}
-
-.chip-error {
-  background-color: var(--error-container);
-  color: var(--on-error-container);
-}
-
-.chip-warning {
-  background-color: var(--warning-container);
-  color: var(--on-warning-container);
-}
-
-/* Status Indicators */
-.status-indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  border-radius: var(--border-radius-sm);
-  font-size: 0.75rem;
-  font-weight: 500;
-}
-
-.status-online {
-  background-color: var(--success-container);
-  color: var(--on-success-container);
-}
-
-.status-offline {
-  background-color: var(--error-container);
-  color: var(--on-error-container);
-}
-
-.status-warning {
-  background-color: var(--warning-container);
-  color: var(--on-warning-container);
-}
-
-.status-pending {
-  background-color: var(--info-container);
-  color: var(--on-info-container);
-}
-
-.status-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background-color: currentColor;
-}
-
-/* Icon Buttons */
+/* ============================================================
+   ICON BUTTONS
+   ============================================================ */
 .icon-btn {
   display: inline-flex;
   align-items: center;
@@ -619,52 +503,580 @@ input::placeholder {
   box-shadow: var(--shadow-1);
 }
 
-/* Typography */
-h1, h2, h3, h4, h5, h6 {
+/* ============================================================
+   FORM ELEMENTS — BASE
+   ============================================================ */
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 16px 12px 8px 12px;
+  border: 1px solid var(--outline-variant);
+  border-radius: 4px;
+  background-color: transparent;
+  color: var(--on-surface);
+  font-family: 'Roboto', sans-serif;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s;
   margin-bottom: var(--spacing-2);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--primary);
+}
+
+input:not(:placeholder-shown) {
+  padding-top: 16px;
+  padding-bottom: 8px;
+}
+
+input::placeholder {
+  color: transparent;
+}
+
+/* Checkboxes/radios override the base width */
+input[type="checkbox"],
+input[type="radio"] {
+  width: auto;
+  margin-bottom: 0;
+  padding: 0;
+}
+
+/* ============================================================
+   TEXT FIELD (floating label) — canonical form pattern
+   Works for: input[type=text/email/number/date], select, textarea
+   JSX: <div className="text-field">
+           <input placeholder=" " ... />
+           <label>Field Label</label>
+         </div>
+   ============================================================ */
+.text-field,
+.input-wrapper {
+  position: relative;
+  margin-bottom: var(--spacing-2);
+  width: 100%;
+}
+
+.text-field input,
+.text-field select,
+.text-field textarea,
+.input-wrapper input,
+.input-wrapper select,
+.input-wrapper textarea {
+  width: 100%;
+  padding: 20px 12px 8px 12px;
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--border-radius-sm);
+  background-color: var(--surface-container-low);
+  color: var(--on-surface);
+  font-family: 'Roboto', sans-serif;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  margin-bottom: 0;
+}
+
+.text-field input:focus,
+.text-field select:focus,
+.text-field textarea:focus,
+.input-wrapper input:focus,
+.input-wrapper select:focus,
+.input-wrapper textarea:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 15%, transparent);
+}
+
+.text-field textarea,
+.input-wrapper textarea {
+  resize: vertical;
+  min-height: 80px;
+  padding-top: 24px;
+}
+
+/* Floating label */
+.text-field label,
+.input-wrapper label {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--on-surface-variant);
+  font-size: 1rem;
+  font-weight: 400;
+  pointer-events: none;
+  transition: top 0.15s, font-size 0.15s, color 0.15s, transform 0.15s;
+  background-color: var(--surface-container-low);
+  padding: 0 4px;
+  z-index: 1;
+}
+
+/* Textarea label starts higher */
+.text-field:has(textarea) label,
+.input-wrapper:has(textarea) label {
+  top: 20px;
+  transform: none;
+}
+
+/* Label floats up when input has value or is focused */
+.text-field input:focus + label,
+.text-field input:not(:placeholder-shown) + label,
+.text-field select:focus + label,
+.text-field select + label,
+.text-field textarea:focus + label,
+.text-field textarea:not(:placeholder-shown) + label,
+.input-wrapper input:focus + label,
+.input-wrapper input:not(:placeholder-shown) + label,
+.input-wrapper select:focus + label,
+.input-wrapper select + label,
+.input-wrapper textarea:focus + label,
+.input-wrapper textarea:not(:placeholder-shown) + label {
+  top: 4px;
+  transform: none;
+  font-size: 0.72rem;
+  color: var(--primary);
+}
+
+/* Error state */
+.text-field.field-error input,
+.text-field.field-error select,
+.text-field.field-error textarea,
+.input-wrapper.field-error input,
+.input-wrapper.field-error select,
+.input-wrapper.field-error textarea {
+  border-color: var(--error);
+  box-shadow: none;
+}
+
+.text-field.field-error label,
+.input-wrapper.field-error label {
+  color: var(--error);
+}
+
+.text-field.field-error input:focus,
+.text-field.field-error select:focus,
+.text-field.field-error textarea:focus,
+.input-wrapper.field-error input:focus,
+.input-wrapper.field-error select:focus,
+.input-wrapper.field-error textarea:focus {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--error) 15%, transparent);
+}
+
+/* Field hint / inline validation message */
+.field-hint {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--on-surface-variant);
+  margin-top: 3px;
+  padding-left: 12px;
+}
+
+.field-error .field-hint,
+.text-field.field-error .field-hint,
+.input-wrapper.field-error .field-hint {
+  color: var(--error);
+}
+
+/* Select — arrow icon + always-floated label */
+.text-field select,
+.input-wrapper select {
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 16px;
+  padding-right: 36px;
+  cursor: pointer;
+}
+
+.text-field select:invalid,
+.input-wrapper select:invalid {
+  color: var(--on-surface-variant);
+}
+
+.text-field select:valid,
+.input-wrapper select:valid {
+  color: var(--on-surface);
+}
+
+.text-field select option,
+.input-wrapper select option {
+  color: var(--on-surface);
+  background-color: var(--surface);
+  padding: 8px;
+}
+
+/* ============================================================
+   CHECKBOX / RADIO — canonical pattern
+   JSX: <label className="check-field">
+           <input type="checkbox" checked={x} onChange={h} />
+           <span>Label text</span>
+         </label>
+   ============================================================ */
+.check-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+  margin-bottom: var(--spacing-1);
+  color: var(--on-surface);
+  font-size: 0.9375rem;
+}
+
+.check-field input[type="checkbox"],
+.check-field input[type="radio"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--primary);
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-bottom: 0;
+  padding: 0;
+}
+
+/* ============================================================
+   FORM GRID — multi-column form layout
+   ============================================================ */
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.form-grid .col-span-2 {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 600px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+  .form-grid .col-span-2 {
+    grid-column: auto;
+  }
+}
+
+/* ============================================================
+   FORM SECTION — group of related fields
+   ============================================================ */
+.form-section {
+  margin-bottom: var(--spacing-3);
+}
+
+.form-section-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--on-surface-variant);
+  margin-bottom: var(--spacing-1);
+  padding-bottom: var(--spacing-1);
+  border-bottom: 1px solid var(--outline-variant);
+}
+
+/* ============================================================
+   FORM ACTIONS — submit/cancel button row
+   ============================================================ */
+.form-actions {
+  display: flex;
+  gap: var(--spacing-1);
+  justify-content: flex-end;
+  padding-top: var(--spacing-2);
+  border-top: 1px solid var(--outline-variant);
+  margin-top: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+/* ============================================================
+   TABLES
+   ============================================================ */
+.table-container {
+  background-color: var(--surface-container-low);
+  border-radius: var(--border-radius-sm);
+  overflow: hidden;
+  box-shadow: none;
+  border: 1px solid var(--outline-variant);
+}
+
+/* .data-table is an alias of .table */
+.table,
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.data-table th {
+  background-color: var(--surface-container);
+  padding: 10px 12px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--on-surface-variant);
+  border-bottom: 1px solid var(--outline-variant);
+  border-right: 1px solid var(--outline-variant);
+  white-space: nowrap;
+}
+
+.table th:last-child,
+.data-table th:last-child {
+  border-right: none;
+}
+
+.table td,
+.data-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--outline-variant);
+  border-right: 1px solid var(--outline-variant);
+  color: var(--on-surface);
+  font-size: 0.9375rem;
+}
+
+.table td:last-child,
+.data-table td:last-child {
+  border-right: none;
+}
+
+.table tr:hover,
+.data-table tr:hover {
+  background-color: var(--surface-variant);
+}
+
+.table tr:last-child td,
+.data-table tr:last-child td {
+  border-bottom: none;
+}
+
+/* ============================================================
+   CHIPS / STATUS BADGES
+   ============================================================ */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--border-radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.chip-primary {
+  background-color: rgba(63, 72, 74, 0.12);
+  color: var(--on-surface);
+}
+
+.chip-secondary {
+  background-color: var(--secondary-container);
+  color: var(--on-secondary-container);
+}
+
+.chip-success {
+  background-color: var(--success-container);
+  color: var(--on-success-container);
+}
+
+.chip-error {
+  background-color: var(--error-container);
+  color: var(--on-error-container);
+}
+
+.chip-warning {
+  background-color: var(--warning-container);
+  color: var(--on-warning-container);
+}
+
+.chip-info {
+  background-color: var(--info-container);
+  color: var(--on-info-container);
+}
+
+.chip-outline {
+  background-color: transparent;
+  border: 1px solid var(--outline-variant);
+  color: var(--on-surface-variant);
+}
+
+/* ============================================================
+   STATUS INDICATORS (dot + label)
+   ============================================================ */
+.status-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: var(--border-radius-sm);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.status-online  { background-color: var(--success-container); color: var(--on-success-container); }
+.status-offline { background-color: var(--error-container);   color: var(--on-error-container); }
+.status-warning { background-color: var(--warning-container); color: var(--on-warning-container); }
+.status-pending { background-color: var(--info-container);    color: var(--on-info-container); }
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: currentColor;
+}
+
+/* ============================================================
+   ALERTS — page-level feedback messages
+   JSX: <div className="alert alert-error">
+           <span className="material-icons">error</span>
+           Message text
+         </div>
+   ============================================================ */
+.alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px var(--spacing-2);
+  border-radius: var(--border-radius-sm);
+  font-size: 0.9375rem;
+  margin-bottom: var(--spacing-2);
+  line-height: 1.5;
+}
+
+.alert .material-icons {
+  font-size: 18px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.alert-error   { background-color: var(--error-container);   color: var(--on-error-container); }
+.alert-success { background-color: var(--success-container); color: var(--on-success-container); }
+.alert-info    { background-color: var(--info-container);    color: var(--on-info-container); }
+.alert-warning { background-color: var(--warning-container); color: var(--on-warning-container); }
+
+/* ============================================================
+   LOADING SPINNER
+   JSX: <div className="loading-spinner" />
+   ============================================================ */
+.loading-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--outline-variant);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: inline-block;
+}
+
+.loading-spinner.small {
+  width: 20px;
+  height: 20px;
+  border-width: 2px;
+}
+
+/* ============================================================
+   MODAL
+   JSX: <div className="modal-backdrop">
+           <div className="modal-card">...</div>
+         </div>
+   ============================================================ */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--spacing-2);
+}
+
+.modal-card {
+  background-color: var(--surface-container-low);
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--outline-variant);
+  padding: var(--spacing-3);
+  max-width: 420px;
+  width: 100%;
+  box-shadow: var(--shadow-2);
+}
+
+.modal-card h3 {
+  margin-top: 0;
+  margin-bottom: var(--spacing-1);
+  font-size: 1.125rem;
+  font-weight: 500;
+}
+
+.modal-actions {
+  display: flex;
+  gap: var(--spacing-1);
+  justify-content: flex-end;
+  margin-top: var(--spacing-2);
+}
+
+/* ============================================================
+   TYPOGRAPHY
+   ============================================================ */
+h1, h2, h3, h4, h5, h6 {
+  margin-bottom: var(--spacing-1);
   color: var(--on-surface);
   font-weight: 400;
 }
 
 h1 {
-  font-size: 2.5rem;
-  font-weight: 400;
-  margin-bottom: var(--spacing-3);
+  font-size: 2rem;
+  font-weight: 500;
+  margin-bottom: var(--spacing-2);
 }
 
 h2 {
-  font-size: 2rem;
-  font-weight: 400;
-  margin-top: var(--spacing-4);
-  margin-bottom: var(--spacing-2);
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin-top: var(--spacing-2);
+  margin-bottom: var(--spacing-1);
 }
 
 h3 {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 500;
-  margin-top: var(--spacing-3);
-  margin-bottom: var(--spacing-2);
+  margin-top: var(--spacing-1);
+  margin-bottom: var(--spacing-1);
 }
 
-/* Utility Classes */
-.hidden { display: none; }
-.flex { display: flex; }
-.items-center { align-items: center; }
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+.hidden          { display: none; }
+.flex            { display: flex; }
+.items-center    { align-items: center; }
 .justify-between { justify-content: space-between; }
-.gap-2 { gap: var(--spacing-1); }
-.gap-4 { gap: var(--spacing-2); }
-.p-2 { padding: var(--spacing-1); }
-.p-4 { padding: var(--spacing-2); }
-.mb-4 { margin-bottom: var(--spacing-2); }
-.text-center { text-align: center; }
+.gap-1           { gap: var(--spacing-1); }
+.gap-2           { gap: var(--spacing-2); }
+/* legacy aliases */
+.gap-2-old       { gap: var(--spacing-1); }
+.gap-4           { gap: var(--spacing-2); }
+.p-2             { padding: var(--spacing-1); }
+.p-4             { padding: var(--spacing-2); }
+.mb-4            { margin-bottom: var(--spacing-2); }
+.text-center     { text-align: center; }
+.text-muted      { color: var(--on-surface-variant); }
+.text-sm         { font-size: 0.875rem; }
 
-/* Animations */
+/* ============================================================
+   ANIMATIONS
+   ============================================================ */
 @keyframes spin {
   from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  to   { transform: rotate(360deg); }
 }
 
-/* Apple-style Switch */
+/* ============================================================
+   APPLE-STYLE SWITCH
+   ============================================================ */
 .switch {
   position: relative;
   display: inline-block;
@@ -716,7 +1128,9 @@ input:disabled + .slider {
   cursor: not-allowed;
 }
 
-/* Responsive */
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
 @media (max-width: 768px) {
   .mobile-menu-btn {
     display: flex;
@@ -725,68 +1139,61 @@ input:disabled + .slider {
     background-color: var(--surface-variant);
     border-radius: var(--border-radius-sm);
   }
-  
+
   .mobile-menu-btn:hover {
     background-color: var(--surface-container);
   }
-  
+
   .sidebar {
     width: 280px;
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     z-index: 999;
   }
-  
+
   .sidebar-mobile-open {
     transform: translateX(0);
   }
-  
+
   .mobile-overlay {
     display: block;
   }
-  
+
   .main {
     margin-left: 0;
   }
-  
+
   .app-bar {
     padding: 16px;
   }
-  
+
   .app-bar-title {
     font-size: 1.1rem;
   }
-  
-  /* Make cards more touch-friendly on mobile */
-  .card {
-    min-height: 120px;
-  }
-  
-  /* Improve button touch targets */
+
   .button {
     min-height: 44px;
     padding: 12px 16px;
   }
-  
+
   .icon-btn {
     min-width: 44px;
     min-height: 44px;
   }
 }
 
-/* Print Styles */
+/* ============================================================
+   PRINT STYLES
+   ============================================================ */
 @media print {
-  /* Hide navigation and non-essential elements */
   .no-print,
   nav,
   .sidebar,
   .app-bar,
-  button.no-print,
-  .alert {
+  button.no-print {
     display: none !important;
   }
 
-  /* Reset page layout for print */
   body {
     background: white;
     color: black;
@@ -794,7 +1201,7 @@ input:disabled + .slider {
     padding: 20px;
   }
 
-  .main-content {
+  .main {
     margin: 0;
     padding: 0;
     max-width: 100%;
@@ -808,7 +1215,6 @@ input:disabled + .slider {
     padding: 20px;
   }
 
-  /* Table styling for print */
   table {
     width: 100%;
     border-collapse: collapse;
@@ -829,7 +1235,6 @@ input:disabled + .slider {
     border: 1px solid #ddd;
   }
 
-  /* Typography adjustments */
   h1, h2, h3, h4, h5, h6 {
     page-break-after: avoid;
     color: black;
@@ -840,29 +1245,19 @@ input:disabled + .slider {
   h3 { font-size: 16pt; }
   h4 { font-size: 14pt; }
 
-  /* Remove background colors */
   * {
     background-color: white !important;
     color: black !important;
   }
 
-  /* Keep table headers */
-  .data-table th {
+  .data-table th,
+  .table th {
     background-color: #f0f0f0 !important;
     font-weight: bold;
   }
 
-  /* Print links with URL */
   a[href]:after {
     content: " (" attr(href) ")";
     font-size: 10pt;
-  }
-
-  /* Status badges */
-  .status-badge,
-  span[style*="border-radius"] {
-    border: 1px solid black !important;
-    padding: 4px 8px !important;
-    display: inline-block !important;
   }
 }


### PR DESCRIPTION
- theme.css: added 22 CSS variable aliases (--color-* → canonical tokens),
  full missing class library (button variants, data-table, modal-backdrop/card,
  loading-spinner, alert variants, form-grid, check-field, form-section,
  form-actions, field-hint, page-header, card-clickable), visual tightening
  (card border-radius sm, typography margins, table header styling)
- Orders/Shipments/Lanes/Customers/Locations: page-header layout, text-field
  filter inputs, modal-backdrop for delete confirms, chip classes for status
- OrderDetails: chip status badges, alert boxes for exceptions and delivery stop
  info, button-danger for archive, text-muted utility classes
- EditOrder/PendingLaneRequests: fixed button-outlined → button-outline and
  button-small → button-sm across all instances
- Dashboard: removed mouseEnter/Leave inline hover hacks → card-clickable CSS class
- Settings: alert-warning for important notice, form-actions row, chip badges

https://claude.ai/code/session_011CUL3aqePnjFpiwXw4arbN