### PR TITLE
Add PRO number support to shipments

### DIFF
--- a/backend/prisma/migrations/20260401_add_shipment_pro_number/migration.sql
+++ b/backend/prisma/migrations/20260401_add_shipment_pro_number/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Shipment" ADD COLUMN "proNumber" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -64,6 +64,7 @@ model Shipment {
   status        String   @default("draft")
   pickupDate    DateTime?
   deliveryDate  DateTime?
+  proNumber     String?
   items         Json?
   archived      Boolean  @default(false)
   archivedAt    DateTime?

--- a/backend/src/repositories/ShipmentsRepository.ts
+++ b/backend/src/repositories/ShipmentsRepository.ts
@@ -14,11 +14,13 @@ export interface CreateShipmentDTO {
   deliveryDate?: string;
   items?: any[];
   status?: string;
+  proNumber?: string;
 }
 
 export interface UpdateShipmentDTO {
   reference?: string;
   status?: string;
+  proNumber?: string;
   pickupDate?: string;
   deliveryDate?: string;
   customerId?: string;

--- a/backend/src/routes/shipments.ts
+++ b/backend/src/routes/shipments.ts
@@ -43,6 +43,7 @@ export async function shipmentRoutes(server: FastifyInstance) {
       destinationId: z.string().uuid().optional(),
       pickupDate: z.string().datetime().optional(),
       deliveryDate: z.string().datetime().optional(),
+      proNumber: z.string().optional(),
       items: z.array(z.object({
         sku: z.string(),
         description: z.string().optional(),
@@ -266,6 +267,7 @@ export async function shipmentRoutes(server: FastifyInstance) {
       customerId: z.string().uuid().optional(),
       laneId: z.string().uuid().optional(),
       carrierId: z.string().uuid().nullable().optional(), // Manual carrier assignment
+      proNumber: z.string().nullable().optional(),
       originId: z.string().uuid().optional(),
       destinationId: z.string().uuid().optional(),
       items: z.array(z.object({

--- a/backend/src/workers/outboundCarrierWorker.ts
+++ b/backend/src/workers/outboundCarrierWorker.ts
@@ -99,6 +99,13 @@ export function createOutboundCarrierWorker(prisma: PrismaClient) {
         });
 
         if (result.success) {
+          const proValue = result.carrierReference || result.trackingNumber;
+          if (proValue && !shipment.proNumber) {
+            await prisma.shipment.update({
+              where: { id: shipment.id },
+              data: { proNumber: proValue },
+            });
+          }
           console.log(`[CarrierWorker] ${eventType} sent to ${integration.name} for ${shipment.reference}`);
         } else {
           console.warn(`[CarrierWorker] Failed: ${integration.name} — ${result.errorMessage}`);

--- a/frontend/src/components/ShipmentCreationForm.tsx
+++ b/frontend/src/components/ShipmentCreationForm.tsx
@@ -35,6 +35,7 @@ interface Shipment {
   laneId?: string;
   originId: string;
   destinationId: string;
+  proNumber?: string | null;
   archived: boolean;
   archivedAt?: string;
   createdAt: string;
@@ -56,6 +57,7 @@ export default function ShipmentCreationForm({
 }: ShipmentCreationFormProps) {
   const [customers, setCustomers] = useState<Customer[]>([]);
   const [reference, setReference] = useState('');
+  const [proNumber, setProNumber] = useState('');
   const [customerId, setCustomerId] = useState('');
   const [useLane, setUseLane] = useState(true);
   const [laneId, setLaneId] = useState('');
@@ -71,6 +73,7 @@ export default function ShipmentCreationForm({
   useEffect(() => {
     if (editingShipment) {
       setReference(editingShipment.reference);
+      setProNumber(editingShipment.proNumber || '');
       setCustomerId(editingShipment.customerId);
 
       // Determine route type based on whether laneId exists
@@ -109,6 +112,7 @@ export default function ShipmentCreationForm({
 
   const clearForm = () => {
     setReference('');
+    setProNumber('');
     setCustomerId('');
     setUseLane(true);
     setLaneId('');
@@ -162,6 +166,7 @@ export default function ShipmentCreationForm({
     try {
       const shipmentData = {
         reference,
+        proNumber: proNumber || undefined,
         customerId,
         ...(useLane
           ? { laneId }
@@ -236,6 +241,15 @@ export default function ShipmentCreationForm({
               disabled={loading}
             />
             <label>Reference</label>
+          </div>
+          <div className="text-field">
+            <input
+              value={proNumber}
+              onChange={e => setProNumber(e.target.value)}
+              placeholder=" "
+              disabled={loading}
+            />
+            <label>PRO Number (optional)</label>
           </div>
           <div className="text-field">
             <select

--- a/frontend/src/pages/ShipmentDetails.tsx
+++ b/frontend/src/pages/ShipmentDetails.tsx
@@ -455,6 +455,7 @@ export default function ShipmentDetails() {
             <h3>Basic Information</h3>
             <div style={{ display: 'grid', gap: '8px' }}>
               <div><strong>Reference:</strong> {shipment.reference}</div>
+              <div><strong>PRO Number:</strong> {shipment.proNumber || '—'}</div>
               <div><strong>Status:</strong> <span className={`chip ${
                 shipment.status === 'delivered' ? 'chip-success' : 
                 shipment.status === 'in_transit' ? 'chip-warning' : 

--- a/frontend/src/pages/Shipments.tsx
+++ b/frontend/src/pages/Shipments.tsx
@@ -35,6 +35,7 @@ interface Shipment {
   laneId?: string;
   originId: string;
   destinationId: string;
+  proNumber?: string | null;
   archived: boolean;
   archivedAt?: string;
   createdAt: string;
@@ -94,6 +95,7 @@ export default function Shipments() {
     if (searchTerm) {
       filtered = filtered.filter(shipment =>
         shipment.reference.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        (shipment.proNumber && shipment.proNumber.toLowerCase().includes(searchTerm.toLowerCase())) ||
         (shipment.customer && shipment.customer.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
         (shipment.origin && shipment.origin.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
         (shipment.destination && shipment.destination.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
@@ -157,7 +159,7 @@ export default function Shipments() {
               onChange={e => setSearchTerm(e.target.value)}
               placeholder=" "
             />
-            <label>Search by reference, customer, lane…</label>
+            <label>Search by reference, PRO #, customer, lane…</label>
           </div>
 
           <div className="text-field">
@@ -218,6 +220,7 @@ export default function Shipments() {
             <thead>
               <tr>
                 <th>Reference</th>
+                <th>PRO #</th>
                 <th>Customer</th>
                 <th>Origin / Lane</th>
                 <th>Destination</th>
@@ -230,7 +233,7 @@ export default function Shipments() {
             <tbody>
               {filteredShipments.length === 0 ? (
                 <tr>
-                  <td colSpan={8} style={{ textAlign: 'center', padding: 'var(--spacing-4)', color: 'var(--on-surface-variant)' }}>
+                  <td colSpan={9} style={{ textAlign: 'center', padding: 'var(--spacing-4)', color: 'var(--on-surface-variant)' }}>
                     {hasActiveFilters ? 'No shipments match your current filters' : 'No shipments found'}
                   </td>
                 </tr>
@@ -249,6 +252,7 @@ export default function Shipments() {
                       {s.reference}
                     </Link>
                   </td>
+                  <td>{s.proNumber || '—'}</td>
                   <td>{s.customer?.name || s.customerId}</td>
                   <td>
                     {s.lane ? (


### PR DESCRIPTION
Add nullable proNumber field to the Shipment model for storing carrier-assigned
tracking identifiers (PRO numbers). Includes manual entry/edit via the shipment
form, display on details and list pages, search filtering, and auto-population
from carrier integration responses.

https://claude.ai/code/session_019xghtQFPeaiZFVKSyQ3B3t