### PR TITLE
Fix CI build: add Prisma client generation before backend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Generate Prisma client
+      run: npx prisma generate --schema=backend/prisma/schema.prisma
+
     - name: Build backend
       run: npm -w backend run build
 


### PR DESCRIPTION
The TypeScript build was failing in CI because `npx prisma generate` was
not run before `tsc`. Without the generated Prisma client, all model type
imports (Attachment, Carrier, Customer, etc.) and Prisma namespace members
(JsonNull, PrismaClientKnownRequestError, etc.) are missing, causing 80+
TS errors.

https://claude.ai/code/session_01KtXy8mATbJYsuMSTJHTP2r