### PR TITLE
Add test suite and CI workflow for PRs and main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate --schema=backend/prisma/schema.prisma
+
+      - name: Build shared package
+        run: npm -w packages/shared run build
+
+      - name: Run backend tests
+        run: npm -w backend run test -- --ci --forceExit
+
+      - name: Run frontend tests
+        run: npm -w frontend run test -- --ci --forceExit

--- a/backend/src/__tests__/apiKeyAuth.test.ts
+++ b/backend/src/__tests__/apiKeyAuth.test.ts
@@ -1,0 +1,72 @@
+import { hashApiKey, redactApiKey, checkRateLimit } from '../middleware/apiKeyAuth';
+
+describe('apiKeyAuth', () => {
+  describe('hashApiKey', () => {
+    it('produces a consistent SHA-256 hex hash', () => {
+      const hash1 = hashApiKey('my-secret-key');
+      const hash2 = hashApiKey('my-secret-key');
+      expect(hash1).toBe(hash2);
+      expect(hash1).toHaveLength(64); // SHA-256 = 64 hex chars
+    });
+
+    it('different keys produce different hashes', () => {
+      const a = hashApiKey('key-a');
+      const b = hashApiKey('key-b');
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('redactApiKey', () => {
+    it('redacts x-api-key header', () => {
+      const headers = { 'x-api-key': 'secret-123', 'content-type': 'application/json' };
+      const redacted = redactApiKey(headers);
+      expect(redacted['x-api-key']).toBe('[REDACTED]');
+      expect(redacted['content-type']).toBe('application/json');
+    });
+
+    it('redacts Authorization Bearer token', () => {
+      const headers = { authorization: 'Bearer my-secret-token' };
+      const redacted = redactApiKey(headers);
+      expect(redacted.authorization).toBe('Bearer [REDACTED]');
+    });
+
+    it('does not modify original headers object', () => {
+      const headers = { 'x-api-key': 'secret' };
+      redactApiKey(headers);
+      expect(headers['x-api-key']).toBe('secret');
+    });
+
+    it('handles headers with no sensitive fields', () => {
+      const headers = { 'content-type': 'text/html' };
+      const redacted = redactApiKey(headers);
+      expect(redacted['content-type']).toBe('text/html');
+    });
+  });
+
+  describe('checkRateLimit', () => {
+    it('allows requests within the limit', () => {
+      const ip = `test-ip-${Date.now()}`;
+      for (let i = 0; i < 100; i++) {
+        expect(checkRateLimit(ip)).toBe(true);
+      }
+    });
+
+    it('blocks requests over the limit', () => {
+      const ip = `test-ip-blocked-${Date.now()}`;
+      for (let i = 0; i < 100; i++) {
+        checkRateLimit(ip);
+      }
+      expect(checkRateLimit(ip)).toBe(false);
+    });
+
+    it('different IPs have independent limits', () => {
+      const ip1 = `ip-a-${Date.now()}`;
+      const ip2 = `ip-b-${Date.now()}`;
+      for (let i = 0; i < 100; i++) {
+        checkRateLimit(ip1);
+      }
+      expect(checkRateLimit(ip1)).toBe(false);
+      expect(checkRateLimit(ip2)).toBe(true);
+    });
+  });
+});

--- a/backend/src/__tests__/container.test.ts
+++ b/backend/src/__tests__/container.test.ts
@@ -1,0 +1,93 @@
+import { container } from '../di/container';
+
+describe('DI Container', () => {
+  afterEach(() => {
+    container.clear();
+  });
+
+  describe('bind', () => {
+    it('binds a factory and resolves it', () => {
+      const token = Symbol.for('test-factory');
+      container.bind(token).toFactory(() => ({ value: 42 }));
+
+      const result = container.resolve<{ value: number }>(token);
+      expect(result.value).toBe(42);
+    });
+
+    it('creates a new instance on every resolve for bind', () => {
+      const token = Symbol.for('test-transient');
+      container.bind(token).toFactory(() => ({ id: Math.random() }));
+
+      const a = container.resolve<{ id: number }>(token);
+      const b = container.resolve<{ id: number }>(token);
+      expect(a).not.toBe(b);
+    });
+
+    it('binds a class constructor', () => {
+      class MyService {
+        name = 'hello';
+      }
+      const token = Symbol.for('test-class');
+      container.bind(token).to(MyService);
+
+      const result = container.resolve<MyService>(token);
+      expect(result.name).toBe('hello');
+    });
+  });
+
+  describe('singleton', () => {
+    it('returns the same instance on every resolve', () => {
+      const token = Symbol.for('test-singleton');
+      container.singleton(token).toFactory(() => ({ id: Math.random() }));
+
+      const a = container.resolve(token);
+      const b = container.resolve(token);
+      expect(a).toBe(b);
+    });
+
+    it('supports class constructors as singletons', () => {
+      class SingleService {
+        readonly ts = Date.now();
+      }
+      const token = Symbol.for('test-singleton-class');
+      container.singleton(token).to(SingleService);
+
+      const a = container.resolve<SingleService>(token);
+      const b = container.resolve<SingleService>(token);
+      expect(a).toBe(b);
+      expect(a.ts).toBe(b.ts);
+    });
+  });
+
+  describe('resolve', () => {
+    it('throws when no binding is found', () => {
+      const token = Symbol.for('missing');
+      expect(() => container.resolve(token)).toThrow('No binding found for token');
+    });
+  });
+
+  describe('has', () => {
+    it('returns true when binding exists', () => {
+      const token = Symbol.for('test-has');
+      container.bind(token).toFactory(() => 'hi');
+      expect(container.has(token)).toBe(true);
+    });
+
+    it('returns false when binding does not exist', () => {
+      expect(container.has(Symbol.for('nope'))).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all bindings and singletons', () => {
+      const token = Symbol.for('test-clear');
+      container.singleton(token).toFactory(() => ({ v: 1 }));
+      container.resolve(token);
+
+      container.clear();
+
+      expect(container.has(token)).toBe(false);
+      expect(() => container.resolve(token)).toThrow();
+    });
+  });
+});

--- a/backend/src/__tests__/csvImportService.test.ts
+++ b/backend/src/__tests__/csvImportService.test.ts
@@ -1,0 +1,153 @@
+import { CSVImportService } from '../services/CSVImportService';
+
+// Create a minimal instance for testing parseCSV (doesn't need real repos)
+const service = new CSVImportService(null as any, null as any, null as any, null as any);
+
+describe('CSVImportService', () => {
+  describe('parseCSV', () => {
+    it('parses a simple CSV with order and line items', () => {
+      const csv = [
+        'Order Number,Customer Name,SKU,Quantity,Service Level',
+        'ORD-001,Acme Corp,SKU-A,10,FTL',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders).toHaveLength(1);
+      expect(orders[0].orderNumber).toBe('ORD-001');
+      expect(orders[0].customerName).toBe('Acme Corp');
+      expect(orders[0].serviceLevel).toBe('FTL');
+    });
+
+    it('groups multiple rows into one order by order number', () => {
+      const csv = [
+        'Order Number,SKU,Quantity,Unit ID,Unit Type',
+        'ORD-002,SKU-A,5,UNIT-1,PALLET',
+        'ORD-002,SKU-B,3,UNIT-1,PALLET',
+        'ORD-002,SKU-C,2,UNIT-2,BOX',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders).toHaveLength(1);
+      expect(orders[0].trackableUnits).toHaveLength(2);
+      expect(orders[0].trackableUnits[0].identifier).toBe('UNIT-1');
+      expect(orders[0].trackableUnits[0].lineItems).toHaveLength(2);
+      expect(orders[0].trackableUnits[1].identifier).toBe('UNIT-2');
+    });
+
+    it('handles multiple orders in one CSV', () => {
+      const csv = [
+        'Order Number,SKU,Quantity',
+        'ORD-A,SKU-1,1',
+        'ORD-B,SKU-2,2',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders).toHaveLength(2);
+    });
+
+    it('normalizes service levels', () => {
+      const csv = [
+        'Order Number,SKU,Quantity,Service Level',
+        'ORD-1,A,1,FTL',
+        'ORD-2,A,1,Full Truck Load',
+        'ORD-3,A,1,LTL',
+        'ORD-4,A,1,',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders[0].serviceLevel).toBe('FTL');
+      expect(orders[1].serviceLevel).toBe('FTL');
+      expect(orders[2].serviceLevel).toBe('LTL');
+      expect(orders[3].serviceLevel).toBe('LTL'); // default
+    });
+
+    it('normalizes temperature control values', () => {
+      const csv = [
+        'Order Number,SKU,Quantity,Temperature Control',
+        'ORD-1,A,1,refrigerated',
+        'ORD-2,A,1,chilled',
+        'ORD-3,A,1,frozen',
+        'ORD-4,A,1,',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders[0].temperatureControl).toBe('refrigerated');
+      expect(orders[1].temperatureControl).toBe('refrigerated');
+      expect(orders[2].temperatureControl).toBe('frozen');
+      expect(orders[3].temperatureControl).toBe('ambient'); // default
+    });
+
+    it('parses hazmat boolean values', () => {
+      const csv = [
+        'Order Number,SKU,Quantity,Requires Hazmat',
+        'ORD-1,A,1,yes',
+        'ORD-2,A,1,true',
+        'ORD-3,A,1,1',
+        'ORD-4,A,1,no',
+        'ORD-5,A,1,',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders[0].requiresHazmat).toBe(true);
+      expect(orders[1].requiresHazmat).toBe(true);
+      expect(orders[2].requiresHazmat).toBe(true);
+      expect(orders[3].requiresHazmat).toBe(false);
+      expect(orders[4].requiresHazmat).toBe(false);
+    });
+
+    it('parses origin and destination address data', () => {
+      const csv = [
+        'Order Number,SKU,Quantity,Origin Name,Origin City,Origin Country,Destination Name,Destination City',
+        'ORD-1,A,1,Dallas Warehouse,Dallas,US,NYC Office,New York',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders[0].originData).toBeDefined();
+      expect(orders[0].originData.name).toBe('Dallas Warehouse');
+      expect(orders[0].originData.city).toBe('Dallas');
+      expect(orders[0].destinationData).toBeDefined();
+      expect(orders[0].destinationData.name).toBe('NYC Office');
+    });
+
+    it('handles quoted CSV fields with commas', () => {
+      const csv = [
+        'Order Number,SKU,Description,Quantity',
+        'ORD-1,A,"Widget, large size",10',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders).toHaveLength(1);
+    });
+
+    it('throws on empty CSV', () => {
+      expect(() => service.parseCSV('')).toThrow('CSV file is empty or has no data rows');
+    });
+
+    it('throws on header-only CSV', () => {
+      expect(() => service.parseCSV('Order Number,SKU')).toThrow('CSV file is empty or has no data rows');
+    });
+
+    it('skips empty rows', () => {
+      const csv = [
+        'Order Number,SKU,Quantity',
+        'ORD-1,A,1',
+        '',
+        '   ',
+        'ORD-2,B,2',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders).toHaveLength(2);
+    });
+
+    it('is case-insensitive for header matching', () => {
+      const csv = [
+        'ORDER NUMBER,sku,Quantity',
+        'ORD-1,ITEM-A,5',
+      ].join('\n');
+
+      const orders = service.parseCSV(csv);
+      expect(orders[0].orderNumber).toBe('ORD-1');
+    });
+  });
+});

--- a/backend/src/__tests__/eventTypes.test.ts
+++ b/backend/src/__tests__/eventTypes.test.ts
@@ -1,0 +1,55 @@
+import { EVENT_TYPES } from '../events/eventTypes';
+
+describe('EVENT_TYPES', () => {
+  it('contains shipment events', () => {
+    expect(EVENT_TYPES.SHIPMENT_CREATED).toBe('shipment.created');
+    expect(EVENT_TYPES.SHIPMENT_UPDATED).toBe('shipment.updated');
+    expect(EVENT_TYPES.SHIPMENT_STATUS_CHANGED).toBe('shipment.status_changed');
+    expect(EVENT_TYPES.SHIPMENT_DELIVERED).toBe('shipment.delivered');
+    expect(EVENT_TYPES.SHIPMENT_EXCEPTION).toBe('shipment.exception');
+  });
+
+  it('contains order events', () => {
+    expect(EVENT_TYPES.ORDER_CREATED).toBe('order.created');
+    expect(EVENT_TYPES.ORDER_UPDATED).toBe('order.updated');
+    expect(EVENT_TYPES.ORDER_STATUS_CHANGED).toBe('order.status_changed');
+    expect(EVENT_TYPES.ORDER_ASSIGNED_TO_SHIPMENT).toBe('order.assigned_to_shipment');
+    expect(EVENT_TYPES.ORDER_DELIVERED).toBe('order.delivered');
+  });
+
+  it('contains carrier events', () => {
+    expect(EVENT_TYPES.CARRIER_CREATED).toBe('carrier.created');
+    expect(EVENT_TYPES.CARRIER_UPDATED).toBe('carrier.updated');
+    expect(EVENT_TYPES.CARRIER_ARCHIVED).toBe('carrier.archived');
+  });
+
+  it('contains customer events', () => {
+    expect(EVENT_TYPES.CUSTOMER_CREATED).toBe('customer.created');
+    expect(EVENT_TYPES.CUSTOMER_UPDATED).toBe('customer.updated');
+    expect(EVENT_TYPES.CUSTOMER_ARCHIVED).toBe('customer.archived');
+  });
+
+  it('contains tracking events', () => {
+    expect(EVENT_TYPES.TRACKING_LOCATION_RECEIVED).toBe('tracking.location_received');
+    expect(EVENT_TYPES.TRACKING_GEOFENCE_ENTERED).toBe('tracking.geofence_entered');
+    expect(EVENT_TYPES.TRACKING_ETA_UPDATED).toBe('tracking.eta_updated');
+  });
+
+  it('contains integration events', () => {
+    expect(EVENT_TYPES.INTEGRATION_OUTBOUND_SENT).toBe('integration.outbound_sent');
+    expect(EVENT_TYPES.INTEGRATION_OUTBOUND_FAILED).toBe('integration.outbound_failed');
+    expect(EVENT_TYPES.INTEGRATION_WEBHOOK_RECEIVED).toBe('integration.webhook_received');
+  });
+
+  it('all values follow entity.action naming convention', () => {
+    for (const [key, value] of Object.entries(EVENT_TYPES)) {
+      expect(value).toMatch(/^[a-z]+\.[a-z_]+$/);
+    }
+  });
+
+  it('all keys are unique', () => {
+    const values = Object.values(EVENT_TYPES);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+});

--- a/backend/src/__tests__/jwtAuth.test.ts
+++ b/backend/src/__tests__/jwtAuth.test.ts
@@ -1,0 +1,183 @@
+import { createHmac } from 'crypto';
+import { authenticateJWT, requirePermission, optionalAuth } from '../middleware/jwtAuth';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'open-tms-dev-secret-change-in-production';
+
+function makeToken(payload: Record<string, any>, secret = JWT_SECRET): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = createHmac('sha256', secret).update(`${header}.${body}`).digest('base64url');
+  return `${header}.${body}.${signature}`;
+}
+
+function mockReq(authHeader?: string): any {
+  return {
+    headers: authHeader ? { authorization: authHeader } : {},
+    user: undefined,
+  };
+}
+
+function mockReply(): any {
+  const reply: any = { statusCode: 200, body: null };
+  reply.code = jest.fn((c: number) => { reply.statusCode = c; return reply; });
+  reply.send = jest.fn((b: any) => { reply.body = b; return reply; });
+  return reply;
+}
+
+describe('jwtAuth', () => {
+  describe('authenticateJWT', () => {
+    it('sets req.user for a valid token', async () => {
+      const payload = {
+        sub: 'user-1',
+        email: 'test@example.com',
+        roles: ['admin'],
+        permissions: ['*'],
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'open-tms-auth',
+      };
+      const token = makeToken(payload);
+      const req = mockReq(`Bearer ${token}`);
+      const reply = mockReply();
+
+      await authenticateJWT(req, reply);
+
+      expect(req.user).toBeDefined();
+      expect(req.user.sub).toBe('user-1');
+      expect(req.user.email).toBe('test@example.com');
+    });
+
+    it('rejects request with no auth header', async () => {
+      const req = mockReq();
+      const reply = mockReply();
+
+      await authenticateJWT(req, reply);
+
+      expect(reply.code).toHaveBeenCalledWith(401);
+      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ error: 'Authorization header required' }));
+    });
+
+    it('rejects expired token', async () => {
+      const payload = {
+        sub: 'user-1',
+        email: 'test@example.com',
+        roles: [],
+        permissions: [],
+        exp: Math.floor(Date.now() / 1000) - 3600,
+      };
+      const token = makeToken(payload);
+      const req = mockReq(`Bearer ${token}`);
+      const reply = mockReply();
+
+      await authenticateJWT(req, reply);
+
+      expect(reply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('rejects token with wrong signature', async () => {
+      const payload = { sub: 'user-1', email: 'a@b.com', roles: [], permissions: [] };
+      const token = makeToken(payload, 'wrong-secret');
+      const req = mockReq(`Bearer ${token}`);
+      const reply = mockReply();
+
+      await authenticateJWT(req, reply);
+
+      expect(reply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('rejects non-Bearer auth scheme', async () => {
+      const req = mockReq('Basic abc123');
+      const reply = mockReply();
+
+      await authenticateJWT(req, reply);
+
+      expect(reply.code).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe('requirePermission', () => {
+    it('allows user with wildcard permission', async () => {
+      const req = mockReq();
+      req.user = { sub: 'u1', permissions: ['*'], roles: [] };
+      const reply = mockReply();
+
+      const handler = requirePermission('orders:read');
+      await handler(req, reply);
+
+      expect(reply.code).not.toHaveBeenCalled();
+    });
+
+    it('allows user with exact permission', async () => {
+      const req = mockReq();
+      req.user = { sub: 'u1', permissions: ['orders:read'], roles: [] };
+      const reply = mockReply();
+
+      const handler = requirePermission('orders:read');
+      await handler(req, reply);
+
+      expect(reply.code).not.toHaveBeenCalled();
+    });
+
+    it('allows user with resource wildcard', async () => {
+      const req = mockReq();
+      req.user = { sub: 'u1', permissions: ['orders:*'], roles: [] };
+      const reply = mockReply();
+
+      const handler = requirePermission('orders:write');
+      await handler(req, reply);
+
+      expect(reply.code).not.toHaveBeenCalled();
+    });
+
+    it('rejects user without required permission', async () => {
+      const req = mockReq();
+      req.user = { sub: 'u1', permissions: ['orders:read'], roles: [] };
+      const reply = mockReply();
+
+      const handler = requirePermission('orders:write');
+      await handler(req, reply);
+
+      expect(reply.code).toHaveBeenCalledWith(403);
+    });
+
+    it('rejects unauthenticated user', async () => {
+      const req = mockReq();
+      const reply = mockReply();
+
+      const handler = requirePermission('orders:read');
+      await handler(req, reply);
+
+      expect(reply.code).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe('optionalAuth', () => {
+    it('sets req.user when valid token is present', async () => {
+      const payload = {
+        sub: 'user-1',
+        email: 'test@example.com',
+        roles: [],
+        permissions: [],
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = makeToken(payload);
+      const req = mockReq(`Bearer ${token}`);
+
+      await optionalAuth(req);
+
+      expect(req.user).toBeDefined();
+      expect(req.user.sub).toBe('user-1');
+    });
+
+    it('does nothing when no auth header present', async () => {
+      const req = mockReq();
+      await optionalAuth(req);
+      expect(req.user).toBeUndefined();
+    });
+
+    it('silently ignores invalid token', async () => {
+      const req = mockReq('Bearer invalid.token.here');
+      await optionalAuth(req);
+      expect(req.user).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/__tests__/unitConversion.test.ts
+++ b/backend/src/__tests__/unitConversion.test.ts
@@ -1,0 +1,143 @@
+import {
+  convertWeight,
+  convertWeightToCanonical,
+  convertDimension,
+  convertDimensionToCanonical,
+  convertTemperature,
+  convertTemperatureToCanonical,
+  convertDistance,
+  convertDistanceToCanonical,
+  resolvePreferences,
+  getUnitLabel,
+} from '../services/unitConversion';
+
+describe('unitConversion', () => {
+  describe('convertWeight', () => {
+    it('converts kg to lb', () => {
+      expect(convertWeight(1, 'lb')).toBeCloseTo(2.20, 1);
+    });
+
+    it('returns kg unchanged', () => {
+      expect(convertWeight(10, 'kg')).toBe(10);
+    });
+
+    it('handles zero', () => {
+      expect(convertWeight(0, 'lb')).toBe(0);
+    });
+  });
+
+  describe('convertWeightToCanonical', () => {
+    it('converts lb to kg', () => {
+      expect(convertWeightToCanonical(2.20462, 'lb')).toBeCloseTo(1, 2);
+    });
+
+    it('returns kg unchanged', () => {
+      expect(convertWeightToCanonical(5, 'kg')).toBe(5);
+    });
+  });
+
+  describe('convertDimension', () => {
+    it('converts cm to inches', () => {
+      expect(convertDimension(2.54, 'in')).toBeCloseTo(1, 0);
+    });
+
+    it('returns cm unchanged', () => {
+      expect(convertDimension(100, 'cm')).toBe(100);
+    });
+  });
+
+  describe('convertDimensionToCanonical', () => {
+    it('converts in to cm', () => {
+      expect(convertDimensionToCanonical(1, 'in')).toBeCloseTo(2.54, 1);
+    });
+
+    it('returns cm unchanged', () => {
+      expect(convertDimensionToCanonical(50, 'cm')).toBe(50);
+    });
+  });
+
+  describe('convertTemperature', () => {
+    it('converts Celsius to Fahrenheit', () => {
+      expect(convertTemperature(0, 'F')).toBe(32);
+      expect(convertTemperature(100, 'F')).toBe(212);
+    });
+
+    it('returns Celsius unchanged', () => {
+      expect(convertTemperature(37, 'C')).toBe(37);
+    });
+  });
+
+  describe('convertTemperatureToCanonical', () => {
+    it('converts Fahrenheit to Celsius', () => {
+      expect(convertTemperatureToCanonical(32, 'F')).toBe(0);
+      expect(convertTemperatureToCanonical(212, 'F')).toBe(100);
+    });
+
+    it('returns Celsius unchanged', () => {
+      expect(convertTemperatureToCanonical(25, 'C')).toBe(25);
+    });
+  });
+
+  describe('convertDistance', () => {
+    it('converts km to miles', () => {
+      expect(convertDistance(1, 'mi')).toBeCloseTo(0.62, 1);
+    });
+
+    it('returns km unchanged', () => {
+      expect(convertDistance(100, 'km')).toBe(100);
+    });
+  });
+
+  describe('convertDistanceToCanonical', () => {
+    it('converts miles to km', () => {
+      expect(convertDistanceToCanonical(1, 'mi')).toBeCloseTo(1.609, 2);
+    });
+
+    it('returns km unchanged', () => {
+      expect(convertDistanceToCanonical(50, 'km')).toBe(50);
+    });
+  });
+
+  describe('resolvePreferences', () => {
+    it('uses org defaults when no user overrides', () => {
+      const prefs = resolvePreferences({ weightUnit: 'lb', dimUnit: 'in' });
+      expect(prefs.weightUnit).toBe('lb');
+      expect(prefs.dimUnit).toBe('in');
+      expect(prefs.temperatureUnit).toBe('C');
+      expect(prefs.distanceUnit).toBe('km');
+    });
+
+    it('user overrides take precedence', () => {
+      const prefs = resolvePreferences(
+        { weightUnit: 'kg' },
+        { weightUnit: 'lb' }
+      );
+      expect(prefs.weightUnit).toBe('lb');
+    });
+
+    it('falls back to metric defaults when nothing specified', () => {
+      const prefs = resolvePreferences({});
+      expect(prefs.weightUnit).toBe('kg');
+      expect(prefs.dimUnit).toBe('cm');
+      expect(prefs.temperatureUnit).toBe('C');
+      expect(prefs.distanceUnit).toBe('km');
+    });
+  });
+
+  describe('getUnitLabel', () => {
+    it('returns display labels', () => {
+      expect(getUnitLabel('weightUnit', 'kg')).toBe('kg');
+      expect(getUnitLabel('weightUnit', 'lb')).toBe('lb');
+      expect(getUnitLabel('temperatureUnit', 'C')).toBe('°C');
+      expect(getUnitLabel('temperatureUnit', 'F')).toBe('°F');
+      expect(getUnitLabel('dimUnit', 'cm')).toBe('cm');
+      expect(getUnitLabel('dimUnit', 'in')).toBe('in');
+      expect(getUnitLabel('distanceUnit', 'km')).toBe('km');
+      expect(getUnitLabel('distanceUnit', 'mi')).toBe('mi');
+    });
+
+    it('returns value as fallback for unknown types', () => {
+      expect(getUnitLabel('weightUnit' as any, 'unknown')).toBe('unknown');
+    });
+  });
+});

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.test.tsx'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',
     '!src/**/*.d.ts',

--- a/frontend/src/__tests__/MapProvider.test.tsx
+++ b/frontend/src/__tests__/MapProvider.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MapProvider, useMapProvider } from '../MapProvider';
+
+function MapConsumer() {
+  const { provider, isLoaded, apiKey } = useMapProvider();
+  return (
+    <div>
+      <span data-testid="provider">{provider}</span>
+      <span data-testid="is-loaded">{String(isLoaded)}</span>
+      <span data-testid="api-key">{apiKey || 'none'}</span>
+    </div>
+  );
+}
+
+describe('MapProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders children', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ data: { apiKey: null } }),
+    });
+
+    await act(async () => {
+      render(
+        <MapProvider>
+          <div data-testid="child">Maps</div>
+        </MapProvider>
+      );
+    });
+
+    expect(screen.getByTestId('child')).toHaveTextContent('Maps');
+  });
+
+  it('falls back to OSM when no API key is returned', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ data: { apiKey: null } }),
+    });
+
+    await act(async () => {
+      render(
+        <MapProvider>
+          <MapConsumer />
+        </MapProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider')).toHaveTextContent('osm');
+      expect(screen.getByTestId('is-loaded')).toHaveTextContent('true');
+      expect(screen.getByTestId('api-key')).toHaveTextContent('none');
+    });
+  });
+
+  it('falls back to OSM when fetch fails', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+    await act(async () => {
+      render(
+        <MapProvider>
+          <MapConsumer />
+        </MapProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider')).toHaveTextContent('osm');
+      expect(screen.getByTestId('is-loaded')).toHaveTextContent('true');
+    });
+  });
+});

--- a/frontend/src/__tests__/ThemeProvider.test.tsx
+++ b/frontend/src/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, useTheme } from '../ThemeProvider';
+
+// Helper component to consume the context
+function ThemeConsumer() {
+  const { hasLogo, logoUrl, systemName } = useTheme();
+  return (
+    <div>
+      <span data-testid="system-name">{systemName}</span>
+      <span data-testid="has-logo">{String(hasLogo)}</span>
+      <span data-testid="logo-url">{logoUrl || 'none'}</span>
+    </div>
+  );
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('renders children', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ data: null }),
+    });
+
+    await act(async () => {
+      render(
+        <ThemeProvider>
+          <div data-testid="child">Hello</div>
+        </ThemeProvider>
+      );
+    });
+
+    expect(screen.getByTestId('child')).toHaveTextContent('Hello');
+  });
+
+  it('provides default system name when API returns no data', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ data: null }),
+    });
+
+    await act(async () => {
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      );
+    });
+
+    expect(screen.getByTestId('system-name')).toHaveTextContent('Open TMS');
+    expect(screen.getByTestId('has-logo')).toHaveTextContent('false');
+    expect(screen.getByTestId('logo-url')).toHaveTextContent('none');
+  });
+
+  it('loads theme from API and updates context', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          data: {
+            themeConfig: { primary: '#ff0000' },
+            themeUpdatedAt: '2024-01-01T00:00:00Z',
+            hasLogo: true,
+            systemName: 'My TMS',
+          },
+        }),
+    });
+
+    await act(async () => {
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('system-name')).toHaveTextContent('My TMS');
+      expect(screen.getByTestId('has-logo')).toHaveTextContent('true');
+    });
+  });
+
+  it('handles fetch failure gracefully', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+    await act(async () => {
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      );
+    });
+
+    // Should still render with defaults
+    expect(screen.getByTestId('system-name')).toHaveTextContent('Open TMS');
+  });
+
+  it('caches theme in sessionStorage', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          data: {
+            themeConfig: { primary: '#00ff00' },
+            themeUpdatedAt: '2024-06-01T00:00:00Z',
+            hasLogo: false,
+            systemName: 'Cached TMS',
+          },
+        }),
+    });
+
+    await act(async () => {
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      );
+    });
+
+    await waitFor(() => {
+      const cached = sessionStorage.getItem('open-tms-theme-cache');
+      expect(cached).not.toBeNull();
+      const parsed = JSON.parse(cached!);
+      expect(parsed.systemName).toBe('Cached TMS');
+    });
+  });
+});

--- a/frontend/src/components/__tests__/AppBar.test.tsx
+++ b/frontend/src/components/__tests__/AppBar.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import AppBar from '../AppBar';
+
+// Mock ThemeProvider
+jest.mock('../../ThemeProvider', () => ({
+  useTheme: () => ({
+    hasLogo: false,
+    logoUrl: null,
+    systemName: 'Open TMS',
+    themeUpdatedAt: null,
+    reloadTheme: jest.fn(),
+  }),
+}));
+
+// Mock AppSwitcher since it has its own tests
+jest.mock('../AppSwitcher', () => ({
+  __esModule: true,
+  default: function MockAppSwitcher() {
+    return React.createElement('div', { 'data-testid': 'app-switcher' });
+  },
+}));
+
+function renderAppBar(props?: Partial<React.ComponentProps<typeof AppBar>>) {
+  const defaultProps = {
+    title: 'Operations',
+    icon: 'local_shipping',
+    onToggleMobileMenu: jest.fn(),
+  };
+  return render(
+    <MemoryRouter>
+      <AppBar {...defaultProps} {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('AppBar', () => {
+  it('renders the title', () => {
+    renderAppBar({ title: 'My Dashboard' });
+    expect(screen.getByText('My Dashboard')).toBeInTheDocument();
+  });
+
+  it('renders the icon', () => {
+    renderAppBar({ icon: 'dashboard' });
+    expect(screen.getByText('dashboard')).toBeInTheDocument();
+  });
+
+  it('renders the mobile menu button', () => {
+    renderAppBar();
+    expect(screen.getByLabelText('Toggle menu')).toBeInTheDocument();
+  });
+
+  it('calls onToggleMobileMenu when hamburger is clicked', () => {
+    const onToggle = jest.fn();
+    renderAppBar({ onToggleMobileMenu: onToggle });
+    fireEvent.click(screen.getByLabelText('Toggle menu'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders notification and account buttons', () => {
+    renderAppBar();
+    expect(screen.getByText('notifications')).toBeInTheDocument();
+    expect(screen.getByText('account_circle')).toBeInTheDocument();
+  });
+
+  it('renders the AppSwitcher', () => {
+    renderAppBar();
+    expect(screen.getByTestId('app-switcher')).toBeInTheDocument();
+  });
+
+  it('does not render logo when hasLogo is false', () => {
+    renderAppBar();
+    expect(screen.queryByAltText('Logo')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/AppSwitcher.test.tsx
+++ b/frontend/src/components/__tests__/AppSwitcher.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import AppSwitcher from '../AppSwitcher';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+function renderSwitcher(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AppSwitcher />
+    </MemoryRouter>
+  );
+}
+
+describe('AppSwitcher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the toggle button', () => {
+    renderSwitcher();
+    expect(screen.getByLabelText('Switch app')).toBeInTheDocument();
+  });
+
+  it('dropdown is hidden by default', () => {
+    renderSwitcher();
+    expect(screen.queryByText('Switch to')).not.toBeInTheDocument();
+  });
+
+  it('opens dropdown on click', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByLabelText('Switch app'));
+    expect(screen.getByText('Switch to')).toBeInTheDocument();
+    expect(screen.getByText('Operations')).toBeInTheDocument();
+    expect(screen.getByText('Integrations')).toBeInTheDocument();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+
+  it('navigates to Integrations on click', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByLabelText('Switch app'));
+    fireEvent.click(screen.getByText('Integrations'));
+    expect(mockNavigate).toHaveBeenCalledWith('/integrations');
+  });
+
+  it('navigates to Admin on click', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByLabelText('Switch app'));
+    fireEvent.click(screen.getByText('Admin'));
+    expect(mockNavigate).toHaveBeenCalledWith('/admin');
+  });
+
+  it('navigates to Operations on click', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByLabelText('Switch app'));
+    fireEvent.click(screen.getByText('Operations'));
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('closes dropdown after selection', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByLabelText('Switch app'));
+    expect(screen.getByText('Switch to')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Admin'));
+    expect(screen.queryByText('Switch to')).not.toBeInTheDocument();
+  });
+
+  it('shows app descriptions', () => {
+    renderSwitcher();
+    fireEvent.click(screen.getByLabelText('Switch app'));
+    expect(screen.getByText('Shipments, orders, lanes & carriers')).toBeInTheDocument();
+    expect(screen.getByText('API keys, webhooks, EDI & outbound')).toBeInTheDocument();
+    expect(screen.getByText('Settings, theme, templates & fields')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/CustomFieldRenderer.test.tsx
+++ b/frontend/src/components/__tests__/CustomFieldRenderer.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CustomFieldRenderer from '../CustomFieldRenderer';
+
+const mockFields = {
+  data: {
+    id: 'version-1',
+    fields: [
+      { fieldKey: 'priority', label: 'Priority', fieldType: 'text', required: true },
+      { fieldKey: 'weight', label: 'Total Weight', fieldType: 'decimal', required: false, config: { decimalPlaces: 2 } },
+      { fieldKey: 'is_fragile', label: 'Fragile', fieldType: 'boolean', required: false },
+      { fieldKey: 'category', label: 'Category', fieldType: 'list', required: false, config: { options: ['Standard', 'Express', 'Priority'] } },
+      { fieldKey: 'tags', label: 'Tags', fieldType: 'multi_list', required: false, config: { options: ['Urgent', 'International', 'Oversized'] } },
+    ],
+  },
+};
+
+describe('CustomFieldRenderer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing while loading', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => new Promise(() => {}), // never resolves
+    });
+
+    const { container } = render(
+      <CustomFieldRenderer entityType="order" values={{}} />
+    );
+
+    // While loading, renders null
+    expect(container.querySelector('h4')).toBeNull();
+  });
+
+  it('renders nothing when no fields are defined', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ data: { id: 'v1', fields: [] } }),
+    });
+
+    const { container } = await act(async () =>
+      render(<CustomFieldRenderer entityType="order" values={{}} />)
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('h4')).toBeNull();
+    });
+  });
+
+  it('renders read-only field values', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve(mockFields),
+    });
+
+    await act(async () => {
+      render(
+        <CustomFieldRenderer
+          entityType="order"
+          values={{ priority: 'High', is_fragile: true }}
+          editable={false}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Custom Fields')).toBeInTheDocument();
+      expect(screen.getByText('Priority')).toBeInTheDocument();
+      expect(screen.getByText('High')).toBeInTheDocument();
+      expect(screen.getByText('Yes')).toBeInTheDocument();
+    });
+  });
+
+  it('renders editable text input', async () => {
+    const onChange = jest.fn();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({
+        data: {
+          id: 'v1',
+          fields: [{ fieldKey: 'note', label: 'Note', fieldType: 'text', required: false }],
+        },
+      }),
+    });
+
+    await act(async () => {
+      render(
+        <CustomFieldRenderer
+          entityType="order"
+          values={{ note: '' }}
+          onChange={onChange}
+          editable={true}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Note')).toBeInTheDocument();
+    });
+  });
+
+  it('renders boolean field as "No" when false', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({
+        data: {
+          id: 'v1',
+          fields: [{ fieldKey: 'flag', label: 'Active', fieldType: 'boolean', required: false }],
+        },
+      }),
+    });
+
+    await act(async () => {
+      render(
+        <CustomFieldRenderer entityType="order" values={{ flag: false }} editable={false} />
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('No')).toBeInTheDocument();
+    });
+  });
+
+  it('fetches by version ID when provided', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ data: { id: 'v2', fields: [] } }),
+    });
+
+    await act(async () => {
+      render(
+        <CustomFieldRenderer entityType="order" versionId="v2" values={{}} />
+      );
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/custom-fields/versions/v2')
+      );
+    });
+  });
+
+  it('fetches active version when no versionId provided', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: () => Promise.resolve({ data: { id: 'active', fields: [] } }),
+    });
+
+    await act(async () => {
+      render(
+        <CustomFieldRenderer entityType="shipment" values={{}} />
+      );
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/custom-fields/shipment')
+      );
+    });
+  });
+
+  it('handles fetch error gracefully', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+
+    const { container } = await act(async () =>
+      render(<CustomFieldRenderer entityType="order" values={{}} />)
+    );
+
+    await waitFor(() => {
+      // Should render nothing on error
+      expect(container.querySelector('h4')).toBeNull();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import Dashboard from '../Dashboard';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../ThemeProvider', () => ({
+  useTheme: () => ({
+    systemName: 'Test TMS',
+    hasLogo: false,
+    logoUrl: null,
+    themeUpdatedAt: null,
+    reloadTheme: jest.fn(),
+  }),
+}));
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>
+  );
+}
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the welcome message with system name', () => {
+    renderDashboard();
+    expect(screen.getByText('Welcome to Test TMS')).toBeInTheDocument();
+  });
+
+  it('renders all navigation cards', () => {
+    renderDashboard();
+    expect(screen.getByText('Customers')).toBeInTheDocument();
+    expect(screen.getByText('Carriers')).toBeInTheDocument();
+    expect(screen.getByText('Locations')).toBeInTheDocument();
+    expect(screen.getByText('Lanes')).toBeInTheDocument();
+    expect(screen.getByText('Shipments')).toBeInTheDocument();
+  });
+
+  it('navigates to customers page on card click', () => {
+    renderDashboard();
+    fireEvent.click(screen.getByText('Customers').closest('.card-clickable')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/customers');
+  });
+
+  it('navigates to carriers page on card click', () => {
+    renderDashboard();
+    fireEvent.click(screen.getByText('Carriers').closest('.card-clickable')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/carriers');
+  });
+
+  it('navigates to locations page on card click', () => {
+    renderDashboard();
+    fireEvent.click(screen.getByText('Locations').closest('.card-clickable')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/locations');
+  });
+
+  it('navigates to lanes page on card click', () => {
+    renderDashboard();
+    fireEvent.click(screen.getByText('Lanes').closest('.card-clickable')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/lanes');
+  });
+
+  it('navigates to shipments page on card click', () => {
+    renderDashboard();
+    fireEvent.click(screen.getByText('Shipments').closest('.card-clickable')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/shipments');
+  });
+
+  it('renders card descriptions', () => {
+    renderDashboard();
+    expect(screen.getByText('Manage your customer database and contact information.')).toBeInTheDocument();
+    expect(screen.getByText('Track and manage your transportation shipments.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/__tests__/geocoding.test.ts
+++ b/frontend/src/services/__tests__/geocoding.test.ts
@@ -1,0 +1,89 @@
+import { nominatimSearch, nominatimReverse } from '../geocoding';
+
+// These tests cover the Nominatim (OSM) implementation which doesn't require
+// Google Maps globals.
+
+describe('geocoding - Nominatim', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('nominatimSearch', () => {
+    it('returns search results from Nominatim', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve([
+            {
+              lat: '32.7767',
+              lon: '-96.7970',
+              display_name: 'Dallas, Texas, United States',
+              address: { city: 'Dallas', state: 'Texas', country: 'United States' },
+            },
+          ]),
+      });
+
+      const results = await nominatimSearch('Dallas TX');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('nominatim.openstreetmap.org/search'),
+        expect.objectContaining({ headers: { 'User-Agent': 'OpenTMS/1.0' } })
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].description).toBe('Dallas, Texas, United States');
+      expect(results[0].lat).toBeCloseTo(32.7767, 3);
+      expect(results[0].lng).toBeCloseTo(-96.797, 3);
+    });
+
+    it('returns empty array on empty response', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        json: () => Promise.resolve([]),
+      });
+
+      const results = await nominatimSearch('nonexistent place');
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('nominatimReverse', () => {
+    it('returns geocoded address from coordinates', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            lat: '32.7767',
+            lon: '-96.7970',
+            display_name: '123 Commerce St, Dallas, TX, US',
+            address: {
+              house_number: '123',
+              road: 'Commerce St',
+              city: 'Dallas',
+              state: 'Texas',
+              postcode: '75201',
+              country: 'United States',
+            },
+          }),
+      });
+
+      const result = await nominatimReverse(32.7767, -96.797);
+
+      expect(result).not.toBeNull();
+      expect(result!.formattedAddress).toBe('123 Commerce St, Dallas, TX, US');
+      expect(result!.address1).toBe('123 Commerce St');
+      expect(result!.city).toBe('Dallas');
+      expect(result!.state).toBe('Texas');
+      expect(result!.postalCode).toBe('75201');
+    });
+
+    it('returns fallback when Nominatim returns no lat', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        json: () => Promise.resolve({ display_name: '' }),
+      });
+
+      const result = await nominatimReverse(40.7128, -74.006);
+
+      expect(result).not.toBeNull();
+      expect(result!.lat).toBe(40.7128);
+      expect(result!.lng).toBe(-74.006);
+      expect(result!.formattedAddress).toContain('40.712800');
+    });
+  });
+});

--- a/frontend/tsconfig.jest.json
+++ b/frontend/tsconfig.jest.json
@@ -4,7 +4,7 @@
     "module": "CommonJS",
     "target": "ES2020",
     "moduleResolution": "node",
-    "types": ["node", "jest", "@testing-library/jest-dom"]
+    "types": ["node", "jest", "@testing-library/jest-dom", "google.maps"]
   },
   "include": ["src/**/*", "src/__tests__/**/*"]
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "concurrently -k -n backend,frontend -c blue,green \"npm -w backend run dev\" \"npm -w frontend run dev\"",
     "lint": "eslint .",
     "format": "prettier --write .",
+    "test": "npm -w backend run test -- --forceExit && npm -w frontend run test -- --forceExit",
     "clean": "rm -rf node_modules package-lock.json frontend/node_modules backend/node_modules packages/*/node_modules",
     "reinstall": "npm run clean && npm install"
   },


### PR DESCRIPTION
- Add GitHub Actions workflow (.github/workflows/test.yml) that runs
  backend and frontend tests on pull requests and pushes to main
- Add root-level `npm test` script
- Backend tests (6 new suites, 73 tests): DI container, unit conversion,
  API key auth, JWT auth, CSV import parsing, event types
- Frontend tests (6 new suites, 43 tests): ThemeProvider, MapProvider,
  AppSwitcher, AppBar, CustomFieldRenderer, Dashboard, geocoding service
- Update frontend jest config to match .ts test files
- Add google.maps types to frontend jest tsconfig

https://claude.ai/code/session_01Fgj5t5yHQUcxzPv49JnscR