### PR TITLE
Add cargo misdrop detection and trackable unit reconciliation

### DIFF
--- a/backend/prisma/migrations/20260410100000_add_cargo_tracking_misdrop_detection/migration.sql
+++ b/backend/prisma/migrations/20260410100000_add_cargo_tracking_misdrop_detection/migration.sql
@@ -1,0 +1,74 @@
+-- AlterTable: Add cargo tracking fields to TrackableUnit
+ALTER TABLE "TrackableUnit" ADD COLUMN "currentStopId" TEXT;
+ALTER TABLE "TrackableUnit" ADD COLUMN "condition" TEXT NOT NULL DEFAULT 'good';
+ALTER TABLE "TrackableUnit" ADD COLUMN "lastScannedAt" TIMESTAMP(3);
+
+-- CreateTable: CargoScan
+CREATE TABLE "CargoScan" (
+    "id" TEXT NOT NULL,
+    "trackableUnitId" TEXT NOT NULL,
+    "shipmentStopId" TEXT NOT NULL,
+    "shipmentId" TEXT NOT NULL,
+    "scanType" TEXT NOT NULL,
+    "scanMethod" TEXT NOT NULL,
+    "scannedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "scannedBy" TEXT,
+    "lat" DOUBLE PRECISION,
+    "lng" DOUBLE PRECISION,
+    "expected" BOOLEAN NOT NULL DEFAULT true,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CargoScan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: CargoDiscrepancy
+CREATE TABLE "CargoDiscrepancy" (
+    "id" TEXT NOT NULL,
+    "shipmentId" TEXT NOT NULL,
+    "trackableUnitId" TEXT NOT NULL,
+    "discrepancyType" TEXT NOT NULL,
+    "severity" TEXT NOT NULL DEFAULT 'high',
+    "expectedStopId" TEXT,
+    "actualStopId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "detectedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "detectedBy" TEXT NOT NULL DEFAULT 'system',
+    "resolvedAt" TIMESTAMP(3),
+    "resolvedBy" TEXT,
+    "resolution" TEXT,
+    "description" TEXT NOT NULL,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CargoDiscrepancy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndexes: CargoScan
+CREATE INDEX "CargoScan_trackableUnitId_idx" ON "CargoScan"("trackableUnitId");
+CREATE INDEX "CargoScan_shipmentStopId_idx" ON "CargoScan"("shipmentStopId");
+CREATE INDEX "CargoScan_shipmentId_idx" ON "CargoScan"("shipmentId");
+CREATE INDEX "CargoScan_scannedAt_idx" ON "CargoScan"("scannedAt");
+
+-- CreateIndexes: CargoDiscrepancy
+CREATE INDEX "CargoDiscrepancy_shipmentId_idx" ON "CargoDiscrepancy"("shipmentId");
+CREATE INDEX "CargoDiscrepancy_trackableUnitId_idx" ON "CargoDiscrepancy"("trackableUnitId");
+CREATE INDEX "CargoDiscrepancy_status_idx" ON "CargoDiscrepancy"("status");
+CREATE INDEX "CargoDiscrepancy_discrepancyType_idx" ON "CargoDiscrepancy"("discrepancyType");
+CREATE INDEX "CargoDiscrepancy_detectedAt_idx" ON "CargoDiscrepancy"("detectedAt");
+
+-- CreateIndex: TrackableUnit.currentStopId
+CREATE INDEX "TrackableUnit_currentStopId_idx" ON "TrackableUnit"("currentStopId");
+
+-- AddForeignKeys
+ALTER TABLE "TrackableUnit" ADD CONSTRAINT "TrackableUnit_currentStopId_fkey" FOREIGN KEY ("currentStopId") REFERENCES "ShipmentStop"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "CargoScan" ADD CONSTRAINT "CargoScan_trackableUnitId_fkey" FOREIGN KEY ("trackableUnitId") REFERENCES "TrackableUnit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CargoScan" ADD CONSTRAINT "CargoScan_shipmentStopId_fkey" FOREIGN KEY ("shipmentStopId") REFERENCES "ShipmentStop"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CargoScan" ADD CONSTRAINT "CargoScan_shipmentId_fkey" FOREIGN KEY ("shipmentId") REFERENCES "Shipment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "CargoDiscrepancy" ADD CONSTRAINT "CargoDiscrepancy_shipmentId_fkey" FOREIGN KEY ("shipmentId") REFERENCES "Shipment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CargoDiscrepancy" ADD CONSTRAINT "CargoDiscrepancy_trackableUnitId_fkey" FOREIGN KEY ("trackableUnitId") REFERENCES "TrackableUnit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CargoDiscrepancy" ADD CONSTRAINT "CargoDiscrepancy_expectedStopId_fkey" FOREIGN KEY ("expectedStopId") REFERENCES "ShipmentStop"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "CargoDiscrepancy" ADD CONSTRAINT "CargoDiscrepancy_actualStopId_fkey" FOREIGN KEY ("actualStopId") REFERENCES "ShipmentStop"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -91,6 +91,10 @@ model Shipment {
   deviceAssignments DeviceAssignment[]    // IoT device assignments
   sensorReadings    SensorReading[]       // Sensor telemetry data
 
+  // Cargo tracking
+  cargoScans        CargoScan[]
+  cargoDiscrepancies CargoDiscrepancy[]
+
   // Custom fields
   customFieldVersionId String?
   customFieldValues    Json?
@@ -133,6 +137,12 @@ model ShipmentStop {
   signatureUrl      String?   // URL to signature image
   photoUrls         Json?     // Array of photo URLs
   proofOfDelivery   Json?     // Additional proof data
+
+  // Cargo tracking relations
+  cargoScans            CargoScan[]
+  discrepanciesExpected CargoDiscrepancy[] @relation("ExpectedStop")
+  discrepanciesActual   CargoDiscrepancy[] @relation("ActualStop")
+  trackableUnitsHere    TrackableUnit[]    @relation("UnitCurrentStop")
 
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
@@ -568,11 +578,22 @@ model TrackableUnit {
   sensorReadings  SensorReading[]
   deviceEvents    DeviceEvent[]
 
+  // Cargo tracking — where this unit physically is right now
+  currentStopId   String?          // Which stop this unit is currently at (null = in transit / on vehicle)
+  currentStop     ShipmentStop?    @relation("UnitCurrentStop", fields: [currentStopId], references: [id])
+  condition       String           @default("good") // good, damaged, lost, unknown
+  lastScannedAt   DateTime?
+
+  // Cargo scan & discrepancy relations
+  cargoScans      CargoScan[]
+  discrepancies   CargoDiscrepancy[]
+
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
   @@unique([orderId, sequenceNumber])
   @@index([orderId])
+  @@index([currentStopId])
 }
 
 model AuditLog {
@@ -1665,4 +1686,80 @@ model DeviceEvent {
   @@index([deviceId, startTime])
   @@index([shipmentId])
   @@index([eventType])
+}
+
+// ============================================================
+// Cargo Tracking & Misdrop Detection
+// ============================================================
+
+// Records physical confirmation of a trackable unit at a specific stop
+model CargoScan {
+  id                String        @id @default(uuid())
+  trackableUnit     TrackableUnit @relation(fields: [trackableUnitId], references: [id], onDelete: Cascade)
+  trackableUnitId   String
+  shipmentStop      ShipmentStop  @relation(fields: [shipmentStopId], references: [id], onDelete: Cascade)
+  shipmentStopId    String
+  shipment          Shipment      @relation(fields: [shipmentId], references: [id], onDelete: Cascade)
+  shipmentId        String
+
+  // Scan details
+  scanType          String        // load, unload, checkpoint
+  scanMethod        String        // barcode, rfid, manual, geofence, iot
+  scannedAt         DateTime      @default(now())
+  scannedBy         String?       // User ID or device ID
+
+  // Location at scan time
+  lat               Float?
+  lng               Float?
+
+  // Result of scan evaluation
+  expected          Boolean       @default(true) // Was this unit expected at this stop?
+  notes             String?
+
+  createdAt         DateTime      @default(now())
+
+  @@index([trackableUnitId])
+  @@index([shipmentStopId])
+  @@index([shipmentId])
+  @@index([scannedAt])
+}
+
+// Tracks cargo discrepancies — misdrops, missing cargo, unexpected deliveries
+model CargoDiscrepancy {
+  id                String        @id @default(uuid())
+  shipment          Shipment      @relation(fields: [shipmentId], references: [id], onDelete: Cascade)
+  shipmentId        String
+  trackableUnit     TrackableUnit @relation(fields: [trackableUnitId], references: [id], onDelete: Cascade)
+  trackableUnitId   String
+
+  // Discrepancy classification
+  discrepancyType   String        // misdrop_early, misdrop_late, missing_at_stop, unexpected_at_stop, left_on_vehicle, damaged, wrong_destination
+  severity          String        @default("high") // critical, high, medium, low
+
+  // Where was it supposed to go vs where it actually went
+  expectedStop      ShipmentStop? @relation("ExpectedStop", fields: [expectedStopId], references: [id])
+  expectedStopId    String?
+  actualStop        ShipmentStop? @relation("ActualStop", fields: [actualStopId], references: [id])
+  actualStopId      String?
+
+  // Lifecycle
+  status            String        @default("open") // open, investigating, resolved, dismissed
+  detectedAt        DateTime      @default(now())
+  detectedBy        String        @default("system") // system, manual, driver, iot
+  resolvedAt        DateTime?
+  resolvedBy        String?
+  resolution        String?       // Description of how it was resolved
+
+  // Context
+  description       String        // Human-readable description of the issue
+  notes             String?
+
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+
+  @@index([shipmentId])
+  @@index([trackableUnitId])
+  @@index([status])
+  @@index([discrepancyType])
+  @@index([detectedAt])
 }

--- a/backend/src/di/registry.ts
+++ b/backend/src/di/registry.ts
@@ -15,6 +15,7 @@ import { OrdersRepository } from '../repositories/OrdersRepository.js';
 import { OrganizationRepository } from '../repositories/OrganizationRepository.js';
 import { PendingLaneRequestsRepository } from '../repositories/PendingLaneRequestsRepository.js';
 import { ArrivalCriteriaRepository } from '../repositories/ArrivalCriteriaRepository.js';
+import { CargoTrackingRepository } from '../repositories/CargoTrackingRepository.js';
 import { LocationResolutionService } from '../services/LocationResolutionService.js';
 import { ArrivalCriteriaEvaluationService } from '../services/ArrivalCriteriaEvaluationService.js';
 import { ShipmentAssignmentService } from '../services/ShipmentAssignmentService.js';
@@ -23,6 +24,7 @@ import { OrderDeliveryService } from '../services/OrderDeliveryService.js';
 import { EDI850ParseService } from '../services/EDI850ParseService.js';
 import { EdiImportService } from '../services/EdiImportService.js';
 import { OrderConversionService } from '../services/OrderConversionService.js';
+import { CargoReconciliationService } from '../services/CargoReconciliationService.js';
 import { DocumentTemplateRepository } from '../repositories/DocumentTemplateRepository.js';
 import { GeneratedDocumentRepository } from '../repositories/GeneratedDocumentRepository.js';
 import { DocumentGenerationService } from '../services/DocumentGenerationService.js';
@@ -89,6 +91,10 @@ export function registerDependencies(prisma: PrismaClient): void {
     return new ArrivalCriteriaRepository(container.resolve(TOKENS.PrismaClient));
   });
 
+  container.singleton(TOKENS.ICargoTrackingRepository).toFactory(() => {
+    return new CargoTrackingRepository(container.resolve(TOKENS.PrismaClient));
+  });
+
   // Register services as singletons
   container.singleton(TOKENS.IShipmentAssignmentService).toFactory(() => {
     return new ShipmentAssignmentService(container.resolve(TOKENS.PrismaClient));
@@ -122,8 +128,23 @@ export function registerDependencies(prisma: PrismaClient): void {
     );
   });
 
+  // Wire up cargo reconciliation into the delivery service (post-construction to avoid circular deps)
+  {
+    const deliveryService = container.resolve<OrderDeliveryService>(TOKENS.IOrderDeliveryService);
+    const cargoService = container.resolve<CargoReconciliationService>(TOKENS.ICargoReconciliationService);
+    deliveryService.setCargoReconciliationService(cargoService);
+  }
+
   container.singleton(TOKENS.IOrderConversionService).toFactory(() => {
     return new OrderConversionService(container.resolve(TOKENS.PrismaClient));
+  });
+
+  container.singleton(TOKENS.ICargoReconciliationService).toFactory(() => {
+    return new CargoReconciliationService(
+      container.resolve(TOKENS.PrismaClient),
+      container.resolve(TOKENS.ICargoTrackingRepository),
+      container.resolve(TOKENS.IEventBus)
+    );
   });
 
   // Document repositories

--- a/backend/src/di/tokens.ts
+++ b/backend/src/di/tokens.ts
@@ -15,6 +15,7 @@ export const TOKENS = {
   IPendingLaneRequestsRepository: Symbol.for('IPendingLaneRequestsRepository'),
 
   IArrivalCriteriaRepository: Symbol.for('IArrivalCriteriaRepository'),
+  ICargoTrackingRepository: Symbol.for('ICargoTrackingRepository'),
 
   // Service tokens
   ILocationResolutionService: Symbol.for('ILocationResolutionService'),
@@ -25,6 +26,7 @@ export const TOKENS = {
   IEDI850ParseService: Symbol.for('IEDI850ParseService'),
   IEdiImportService: Symbol.for('IEdiImportService'),
   IOrderConversionService: Symbol.for('IOrderConversionService'),
+  ICargoReconciliationService: Symbol.for('ICargoReconciliationService'),
 
   // Document tokens
   IDocumentTemplateRepository: Symbol.for('IDocumentTemplateRepository'),

--- a/backend/src/events/eventTypes.ts
+++ b/backend/src/events/eventTypes.ts
@@ -56,6 +56,13 @@ export const EVENT_TYPES = {
   TRACKING_GEOFENCE_ENTERED: 'tracking.geofence_entered',
   TRACKING_ETA_UPDATED: 'tracking.eta_updated',
 
+  // Cargo tracking & misdrop detection
+  CARGO_SCAN_RECORDED: 'cargo.scan_recorded',
+  CARGO_MISDROP_DETECTED: 'cargo.misdrop_detected',
+  CARGO_MISSING_AT_STOP: 'cargo.missing_at_stop',
+  CARGO_LEFT_ON_VEHICLE: 'cargo.left_on_vehicle',
+  CARGO_DISCREPANCY_RESOLVED: 'cargo.discrepancy_resolved',
+
   // Triage (Phase 4)
   TRIAGE_ISSUE_CREATED: 'triage.issue_created',
   TRIAGE_ISSUE_ASSIGNED: 'triage.issue_assigned',
@@ -129,6 +136,36 @@ export interface TrackingLocationReceivedPayload {
   lng: number;
   eventTime: string;
   deviceId?: string;
+}
+
+export interface CargoMisdropPayload {
+  shipmentId: string;
+  trackableUnitId: string;
+  unitIdentifier: string;
+  unitType: string;
+  discrepancyType: string;
+  expectedStop: string;
+  actualStop: string;
+  orderId: string;
+  orderNumber: string;
+}
+
+export interface CargoMissingPayload {
+  shipmentId: string;
+  trackableUnitId: string;
+  unitIdentifier: string;
+  unitType: string;
+  stopName: string;
+  orderNumber: string;
+}
+
+export interface CargoLeftOnVehiclePayload {
+  shipmentId: string;
+  trackableUnitId: string;
+  unitIdentifier: string;
+  unitType: string;
+  orderId: string;
+  orderNumber: string;
 }
 
 export interface EntityChangedPayload {

--- a/backend/src/events/handlers/InAppNotificationHandler.ts
+++ b/backend/src/events/handlers/InAppNotificationHandler.ts
@@ -59,6 +59,34 @@ function buildNotification(event: DomainEvent): { title: string; body: string; c
         category: 'order_update',
         severity: 'info',
       };
+    case 'cargo.misdrop_detected':
+      return {
+        title: `Cargo misdrop: ${p.unitIdentifier || 'Unknown unit'}`,
+        body: `${p.unitType} "${p.unitIdentifier}" was delivered to ${p.actualStop} but expected at ${p.expectedStop} (Order ${p.orderNumber})`,
+        category: 'exception',
+        severity: 'error',
+      };
+    case 'cargo.missing_at_stop':
+      return {
+        title: `Cargo missing: ${p.unitIdentifier || 'Unknown unit'}`,
+        body: `${p.unitType} "${p.unitIdentifier}" was not found at ${p.stopName} (Order ${p.orderNumber})`,
+        category: 'exception',
+        severity: 'warning',
+      };
+    case 'cargo.left_on_vehicle':
+      return {
+        title: `Cargo left on vehicle: ${p.unitIdentifier || 'Unknown unit'}`,
+        body: `${p.unitType} "${p.unitIdentifier}" was never confirmed delivered — may still be on the vehicle (Order ${p.orderNumber})`,
+        category: 'exception',
+        severity: 'error',
+      };
+    case 'cargo.discrepancy_resolved':
+      return {
+        title: `Cargo issue resolved: ${p.unitIdentifier || 'Unknown unit'}`,
+        body: p.resolution || `Discrepancy for ${p.unitIdentifier} has been resolved`,
+        category: 'order_update',
+        severity: 'success',
+      };
     default:
       return null;
   }
@@ -73,6 +101,10 @@ export class InAppNotificationHandler implements IEventHandler {
     'order.status_changed',
     'order.exception',
     'order.delivered',
+    'cargo.misdrop_detected',
+    'cargo.missing_at_stop',
+    'cargo.left_on_vehicle',
+    'cargo.discrepancy_resolved',
   ];
   readonly options: SubscribeOptions = {
     concurrency: 3,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -52,6 +52,7 @@ import { ediTenderRoutes } from './routes/ediTender.js';
 import { tradingPartnerRoutes } from './routes/tradingPartners.js';
 import deviceRoutes from './routes/devices.js';
 import telemetryRoutes from './routes/telemetry.js';
+import { cargoTrackingRoutes } from './routes/cargoTracking.js';
 
 const server = Fastify({ logger: true });
 
@@ -121,6 +122,7 @@ async function start() {
   await server.register(tradingPartnerRoutes);
   await server.register(deviceRoutes);
   await server.register(telemetryRoutes);
+  await server.register(cargoTrackingRoutes);
 
   // Start queue adapter (needed for publishing events, even if workers run elsewhere)
   try {

--- a/backend/src/repositories/CargoTrackingRepository.ts
+++ b/backend/src/repositories/CargoTrackingRepository.ts
@@ -1,0 +1,354 @@
+import { PrismaClient, CargoScan, CargoDiscrepancy } from '@prisma/client';
+
+// ─── DTOs ─────────────────────────────────────────────────────────────────────
+
+export interface CreateCargoScanDTO {
+  trackableUnitId: string;
+  shipmentStopId: string;
+  shipmentId: string;
+  scanType: 'load' | 'unload' | 'checkpoint';
+  scanMethod: 'barcode' | 'rfid' | 'manual' | 'geofence' | 'iot';
+  scannedBy?: string;
+  lat?: number;
+  lng?: number;
+  expected?: boolean;
+  notes?: string;
+}
+
+export interface CreateCargoDiscrepancyDTO {
+  shipmentId: string;
+  trackableUnitId: string;
+  discrepancyType: 'misdrop_early' | 'misdrop_late' | 'missing_at_stop' | 'unexpected_at_stop' | 'left_on_vehicle' | 'damaged' | 'wrong_destination';
+  severity?: 'critical' | 'high' | 'medium' | 'low';
+  expectedStopId?: string;
+  actualStopId?: string;
+  detectedBy?: string;
+  description: string;
+  notes?: string;
+}
+
+export interface UpdateCargoDiscrepancyDTO {
+  status?: 'open' | 'investigating' | 'resolved' | 'dismissed';
+  resolvedBy?: string;
+  resolution?: string;
+  notes?: string;
+  severity?: 'critical' | 'high' | 'medium' | 'low';
+}
+
+// ─── Interface ────────────────────────────────────────────────────────────────
+
+export interface ICargoTrackingRepository {
+  // Cargo Scans
+  createScan(data: CreateCargoScanDTO): Promise<CargoScan>;
+  findScansByShipment(shipmentId: string): Promise<CargoScan[]>;
+  findScansByStop(shipmentStopId: string): Promise<CargoScan[]>;
+  findScansByUnit(trackableUnitId: string): Promise<CargoScan[]>;
+
+  // Cargo Discrepancies
+  createDiscrepancy(data: CreateCargoDiscrepancyDTO): Promise<CargoDiscrepancy>;
+  findDiscrepanciesByShipment(shipmentId: string): Promise<CargoDiscrepancy[]>;
+  findOpenDiscrepancies(): Promise<CargoDiscrepancy[]>;
+  findDiscrepancyById(id: string): Promise<CargoDiscrepancy | null>;
+  updateDiscrepancy(id: string, data: UpdateCargoDiscrepancyDTO): Promise<CargoDiscrepancy>;
+
+  // Cargo Manifest — expected vs actual at each stop
+  getCargoManifest(shipmentId: string): Promise<CargoManifestResult>;
+
+  // Update trackable unit location
+  updateUnitLocation(trackableUnitId: string, currentStopId: string | null, condition?: string): Promise<void>;
+}
+
+export interface CargoManifestStop {
+  stopId: string;
+  sequenceNumber: number;
+  locationName: string;
+  stopType: string;
+  status: string;
+  expectedUnits: ManifestUnit[];
+  scannedUnits: ManifestUnit[];
+  discrepancies: CargoDiscrepancy[];
+}
+
+export interface ManifestUnit {
+  id: string;
+  identifier: string;
+  unitType: string;
+  barcode: string | null;
+  condition: string;
+  currentStopId: string | null;
+  orderId: string;
+  orderNumber: string;
+  lineItemCount: number;
+  lastScannedAt: Date | null;
+}
+
+export interface CargoManifestResult {
+  shipmentId: string;
+  stops: CargoManifestStop[];
+  unassignedUnits: ManifestUnit[];
+  totalExpected: number;
+  totalScanned: number;
+  totalDiscrepancies: number;
+}
+
+// ─── Implementation ───────────────────────────────────────────────────────────
+
+export class CargoTrackingRepository implements ICargoTrackingRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async createScan(data: CreateCargoScanDTO): Promise<CargoScan> {
+    // Also update the trackable unit's last scanned time
+    await this.prisma.trackableUnit.update({
+      where: { id: data.trackableUnitId },
+      data: { lastScannedAt: new Date() },
+    });
+
+    return this.prisma.cargoScan.create({ data });
+  }
+
+  async findScansByShipment(shipmentId: string): Promise<CargoScan[]> {
+    return this.prisma.cargoScan.findMany({
+      where: { shipmentId },
+      orderBy: { scannedAt: 'desc' },
+      include: {
+        trackableUnit: { include: { order: true } },
+        shipmentStop: { include: { location: true } },
+      },
+    });
+  }
+
+  async findScansByStop(shipmentStopId: string): Promise<CargoScan[]> {
+    return this.prisma.cargoScan.findMany({
+      where: { shipmentStopId },
+      orderBy: { scannedAt: 'desc' },
+      include: {
+        trackableUnit: { include: { order: true } },
+      },
+    });
+  }
+
+  async findScansByUnit(trackableUnitId: string): Promise<CargoScan[]> {
+    return this.prisma.cargoScan.findMany({
+      where: { trackableUnitId },
+      orderBy: { scannedAt: 'desc' },
+      include: {
+        shipmentStop: { include: { location: true } },
+      },
+    });
+  }
+
+  async createDiscrepancy(data: CreateCargoDiscrepancyDTO): Promise<CargoDiscrepancy> {
+    return this.prisma.cargoDiscrepancy.create({
+      data,
+      include: {
+        trackableUnit: { include: { order: true } },
+        expectedStop: { include: { location: true } },
+        actualStop: { include: { location: true } },
+      },
+    });
+  }
+
+  async findDiscrepanciesByShipment(shipmentId: string): Promise<CargoDiscrepancy[]> {
+    return this.prisma.cargoDiscrepancy.findMany({
+      where: { shipmentId },
+      orderBy: { detectedAt: 'desc' },
+      include: {
+        trackableUnit: { include: { order: true } },
+        expectedStop: { include: { location: true } },
+        actualStop: { include: { location: true } },
+      },
+    });
+  }
+
+  async findOpenDiscrepancies(): Promise<CargoDiscrepancy[]> {
+    return this.prisma.cargoDiscrepancy.findMany({
+      where: { status: { in: ['open', 'investigating'] } },
+      orderBy: [{ severity: 'asc' }, { detectedAt: 'desc' }],
+      include: {
+        shipment: true,
+        trackableUnit: { include: { order: true } },
+        expectedStop: { include: { location: true } },
+        actualStop: { include: { location: true } },
+      },
+    });
+  }
+
+  async findDiscrepancyById(id: string): Promise<CargoDiscrepancy | null> {
+    return this.prisma.cargoDiscrepancy.findUnique({
+      where: { id },
+      include: {
+        shipment: true,
+        trackableUnit: { include: { order: true, lineItems: true } },
+        expectedStop: { include: { location: true } },
+        actualStop: { include: { location: true } },
+      },
+    });
+  }
+
+  async updateDiscrepancy(id: string, data: UpdateCargoDiscrepancyDTO): Promise<CargoDiscrepancy> {
+    const updateData: any = { ...data };
+    if (data.status === 'resolved') {
+      updateData.resolvedAt = new Date();
+    }
+    return this.prisma.cargoDiscrepancy.update({
+      where: { id },
+      data: updateData,
+      include: {
+        trackableUnit: { include: { order: true } },
+        expectedStop: { include: { location: true } },
+        actualStop: { include: { location: true } },
+      },
+    });
+  }
+
+  async updateUnitLocation(trackableUnitId: string, currentStopId: string | null, condition?: string): Promise<void> {
+    const data: any = { currentStopId };
+    if (condition) data.condition = condition;
+    await this.prisma.trackableUnit.update({
+      where: { id: trackableUnitId },
+      data,
+    });
+  }
+
+  async getCargoManifest(shipmentId: string): Promise<CargoManifestResult> {
+    // Get all stops for the shipment with their expected orders and trackable units
+    const stops = await this.prisma.shipmentStop.findMany({
+      where: { shipmentId },
+      orderBy: { sequenceNumber: 'asc' },
+      include: {
+        location: true,
+        orders: {
+          include: {
+            trackableUnits: {
+              include: { lineItems: true },
+            },
+          },
+        },
+        cargoScans: {
+          include: {
+            trackableUnit: {
+              include: { order: true, lineItems: true },
+            },
+          },
+        },
+        discrepanciesExpected: {
+          include: {
+            trackableUnit: { include: { order: true } },
+            actualStop: { include: { location: true } },
+          },
+        },
+      },
+    });
+
+    // Get all orders for this shipment (including those not assigned to stops)
+    const orderShipments = await this.prisma.orderShipment.findMany({
+      where: { shipmentId },
+      include: {
+        order: {
+          include: {
+            trackableUnits: { include: { lineItems: true } },
+          },
+        },
+      },
+    });
+
+    let totalExpected = 0;
+    let totalScanned = 0;
+    let totalDiscrepancies = 0;
+
+    const manifestStops: CargoManifestStop[] = stops.map((stop) => {
+      // Expected units: trackable units from orders assigned to this stop
+      const expectedUnits: ManifestUnit[] = [];
+      for (const order of stop.orders) {
+        for (const unit of order.trackableUnits) {
+          expectedUnits.push({
+            id: unit.id,
+            identifier: unit.identifier,
+            unitType: unit.unitType,
+            barcode: unit.barcode,
+            condition: (unit as any).condition || 'good',
+            currentStopId: (unit as any).currentStopId || null,
+            orderId: order.id,
+            orderNumber: order.orderNumber,
+            lineItemCount: unit.lineItems.length,
+            lastScannedAt: (unit as any).lastScannedAt || null,
+          });
+        }
+      }
+
+      // Scanned units: from cargo scans at this stop (unload type)
+      const scannedUnitIds = new Set<string>();
+      const scannedUnits: ManifestUnit[] = [];
+      for (const scan of stop.cargoScans.filter((s) => s.scanType === 'unload')) {
+        if (!scannedUnitIds.has(scan.trackableUnitId)) {
+          scannedUnitIds.add(scan.trackableUnitId);
+          const unit = scan.trackableUnit;
+          scannedUnits.push({
+            id: unit.id,
+            identifier: unit.identifier,
+            unitType: unit.unitType,
+            barcode: unit.barcode,
+            condition: (unit as any).condition || 'good',
+            currentStopId: (unit as any).currentStopId || null,
+            orderId: unit.orderId,
+            orderNumber: (unit as any).order?.orderNumber || '',
+            lineItemCount: unit.lineItems?.length || 0,
+            lastScannedAt: (unit as any).lastScannedAt || null,
+          });
+        }
+      }
+
+      totalExpected += expectedUnits.length;
+      totalScanned += scannedUnits.length;
+      totalDiscrepancies += stop.discrepanciesExpected.length;
+
+      return {
+        stopId: stop.id,
+        sequenceNumber: stop.sequenceNumber,
+        locationName: stop.location.name,
+        stopType: stop.stopType,
+        status: stop.status,
+        expectedUnits,
+        scannedUnits,
+        discrepancies: stop.discrepanciesExpected as any,
+      };
+    });
+
+    // Find trackable units not assigned to any stop
+    const assignedUnitIds = new Set<string>();
+    for (const stop of manifestStops) {
+      for (const unit of stop.expectedUnits) {
+        assignedUnitIds.add(unit.id);
+      }
+    }
+
+    const unassignedUnits: ManifestUnit[] = [];
+    for (const os of orderShipments) {
+      for (const unit of os.order.trackableUnits) {
+        if (!assignedUnitIds.has(unit.id)) {
+          unassignedUnits.push({
+            id: unit.id,
+            identifier: unit.identifier,
+            unitType: unit.unitType,
+            barcode: unit.barcode,
+            condition: (unit as any).condition || 'good',
+            currentStopId: (unit as any).currentStopId || null,
+            orderId: os.order.id,
+            orderNumber: os.order.orderNumber,
+            lineItemCount: unit.lineItems.length,
+            lastScannedAt: (unit as any).lastScannedAt || null,
+          });
+        }
+      }
+    }
+
+    return {
+      shipmentId,
+      stops: manifestStops,
+      unassignedUnits,
+      totalExpected,
+      totalScanned,
+      totalDiscrepancies,
+    };
+  }
+}

--- a/backend/src/routes/cargoTracking.ts
+++ b/backend/src/routes/cargoTracking.ts
@@ -1,0 +1,274 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { ICargoTrackingRepository } from '../repositories/CargoTrackingRepository.js';
+import { ICargoReconciliationService } from '../services/CargoReconciliationService.js';
+import { container, TOKENS } from '../di/index.js';
+import { IEventBus, EVENT_TYPES, createEvent } from '../events/index.js';
+
+export async function cargoTrackingRoutes(server: FastifyInstance) {
+  const cargoRepo = container.resolve<ICargoTrackingRepository>(TOKENS.ICargoTrackingRepository);
+  const reconciliationService = container.resolve<ICargoReconciliationService>(TOKENS.ICargoReconciliationService);
+
+  // ─── Cargo Manifest ────────────────────────────────────────────────────────
+
+  server.get('/api/v1/shipments/:shipmentId/cargo-manifest', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Get cargo manifest for a shipment — expected vs actual cargo at each stop',
+      params: {
+        type: 'object',
+        properties: { shipmentId: { type: 'string', format: 'uuid' } },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { shipmentId } = req.params as { shipmentId: string };
+    try {
+      const manifest = await cargoRepo.getCargoManifest(shipmentId);
+      return { data: manifest, error: null };
+    } catch (err: any) {
+      reply.code(500);
+      return { data: null, error: err.message };
+    }
+  });
+
+  // ─── Cargo Scans ───────────────────────────────────────────────────────────
+
+  server.post('/api/v1/cargo-scans', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Record a cargo scan (load, unload, checkpoint) at a stop. Automatically evaluates for misdrops.',
+      body: {
+        type: 'object',
+        required: ['trackableUnitId', 'shipmentStopId', 'shipmentId', 'scanType', 'scanMethod'],
+        properties: {
+          trackableUnitId: { type: 'string', format: 'uuid' },
+          shipmentStopId: { type: 'string', format: 'uuid' },
+          shipmentId: { type: 'string', format: 'uuid' },
+          scanType: { type: 'string', enum: ['load', 'unload', 'checkpoint'] },
+          scanMethod: { type: 'string', enum: ['barcode', 'rfid', 'manual', 'geofence', 'iot'] },
+          scannedBy: { type: 'string' },
+          lat: { type: 'number' },
+          lng: { type: 'number' },
+          notes: { type: 'string' },
+        },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const body = req.body as any;
+    try {
+      const result = await reconciliationService.recordCargoScan(body);
+      reply.code(201);
+      return { data: result, error: null };
+    } catch (err: any) {
+      reply.code(400);
+      return { data: null, error: err.message };
+    }
+  });
+
+  server.get('/api/v1/shipments/:shipmentId/cargo-scans', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Get all cargo scans for a shipment',
+      params: {
+        type: 'object',
+        properties: { shipmentId: { type: 'string', format: 'uuid' } },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { shipmentId } = req.params as { shipmentId: string };
+    try {
+      const scans = await cargoRepo.findScansByShipment(shipmentId);
+      return { data: scans, error: null };
+    } catch (err: any) {
+      reply.code(500);
+      return { data: null, error: err.message };
+    }
+  });
+
+  server.get('/api/v1/shipment-stops/:stopId/cargo-scans', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Get all cargo scans for a specific stop',
+      params: {
+        type: 'object',
+        properties: { stopId: { type: 'string', format: 'uuid' } },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { stopId } = req.params as { stopId: string };
+    try {
+      const scans = await cargoRepo.findScansByStop(stopId);
+      return { data: scans, error: null };
+    } catch (err: any) {
+      reply.code(500);
+      return { data: null, error: err.message };
+    }
+  });
+
+  // ─── Cargo Discrepancies ───────────────────────────────────────────────────
+
+  server.get('/api/v1/shipments/:shipmentId/cargo-discrepancies', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Get all cargo discrepancies for a shipment',
+      params: {
+        type: 'object',
+        properties: { shipmentId: { type: 'string', format: 'uuid' } },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { shipmentId } = req.params as { shipmentId: string };
+    try {
+      const discrepancies = await cargoRepo.findDiscrepanciesByShipment(shipmentId);
+      return { data: discrepancies, error: null };
+    } catch (err: any) {
+      reply.code(500);
+      return { data: null, error: err.message };
+    }
+  });
+
+  server.get('/api/v1/cargo-discrepancies', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Get all open cargo discrepancies across all shipments',
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    try {
+      const discrepancies = await cargoRepo.findOpenDiscrepancies();
+      return { data: discrepancies, error: null };
+    } catch (err: any) {
+      reply.code(500);
+      return { data: null, error: err.message };
+    }
+  });
+
+  server.get('/api/v1/cargo-discrepancies/:id', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Get a specific cargo discrepancy by ID',
+      params: {
+        type: 'object',
+        properties: { id: { type: 'string', format: 'uuid' } },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { id } = req.params as { id: string };
+    try {
+      const discrepancy = await cargoRepo.findDiscrepancyById(id);
+      if (!discrepancy) {
+        reply.code(404);
+        return { data: null, error: 'Discrepancy not found' };
+      }
+      return { data: discrepancy, error: null };
+    } catch (err: any) {
+      reply.code(500);
+      return { data: null, error: err.message };
+    }
+  });
+
+  server.patch('/api/v1/cargo-discrepancies/:id', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Update a cargo discrepancy (status, resolution, notes)',
+      params: {
+        type: 'object',
+        properties: { id: { type: 'string', format: 'uuid' } },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', enum: ['open', 'investigating', 'resolved', 'dismissed'] },
+          resolvedBy: { type: 'string' },
+          resolution: { type: 'string' },
+          notes: { type: 'string' },
+          severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low'] },
+        },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { id } = req.params as { id: string };
+    const body = req.body as any;
+    try {
+      const existing = await cargoRepo.findDiscrepancyById(id);
+      if (!existing) {
+        reply.code(404);
+        return { data: null, error: 'Discrepancy not found' };
+      }
+
+      const updated = await cargoRepo.updateDiscrepancy(id, body);
+
+      // If resolved, publish event
+      if (body.status === 'resolved') {
+        const unit = (updated as any).trackableUnit;
+        try {
+          const eventBus = container.resolve<any>(TOKENS.IEventBus);
+          const { randomUUID } = await import('crypto');
+          await eventBus.publish({
+            id: randomUUID(),
+            type: EVENT_TYPES.CARGO_DISCREPANCY_RESOLVED,
+            timestamp: new Date().toISOString(),
+            orgId: 'default',
+            actorId: body.resolvedBy || null,
+            entityType: 'cargo_discrepancy',
+            entityId: id,
+            payload: {
+              shipmentId: (updated as any).shipmentId,
+              trackableUnitId: (updated as any).trackableUnitId,
+              unitIdentifier: unit?.identifier,
+              unitType: unit?.unitType,
+              discrepancyType: (updated as any).discrepancyType,
+              resolution: body.resolution,
+            },
+            metadata: { correlationId: randomUUID(), source: 'api', schemaVersion: 1 },
+          });
+        } catch { /* best-effort */ }
+      }
+
+      return { data: updated, error: null };
+    } catch (err: any) {
+      reply.code(400);
+      return { data: null, error: err.message };
+    }
+  });
+
+  // ─── Reconciliation Triggers ───────────────────────────────────────────────
+
+  server.post('/api/v1/shipment-stops/:stopId/reconcile-cargo', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Trigger cargo reconciliation for a specific stop (compares expected vs scanned)',
+      params: {
+        type: 'object',
+        properties: { stopId: { type: 'string', format: 'uuid' } },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { stopId } = req.params as { stopId: string };
+    try {
+      const result = await reconciliationService.reconcileStopCompletion(stopId);
+      return { data: result, error: null };
+    } catch (err: any) {
+      reply.code(400);
+      return { data: null, error: err.message };
+    }
+  });
+
+  server.post('/api/v1/shipments/:shipmentId/check-left-on-vehicle', {
+    schema: {
+      tags: ['Cargo Tracking'],
+      description: 'Check for cargo left on vehicle after all stops are completed',
+      params: {
+        type: 'object',
+        properties: { shipmentId: { type: 'string', format: 'uuid' } },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { shipmentId } = req.params as { shipmentId: string };
+    try {
+      const result = await reconciliationService.checkLeftOnVehicle(shipmentId);
+      return { data: result, error: null };
+    } catch (err: any) {
+      reply.code(400);
+      return { data: null, error: err.message };
+    }
+  });
+}

--- a/backend/src/services/CargoReconciliationService.ts
+++ b/backend/src/services/CargoReconciliationService.ts
@@ -1,0 +1,398 @@
+import { PrismaClient } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import {
+  ICargoTrackingRepository,
+  CreateCargoScanDTO,
+  CreateCargoDiscrepancyDTO,
+} from '../repositories/CargoTrackingRepository.js';
+import { IEventBus } from '../events/IEventBus.js';
+import { DomainEvent } from '../events/DomainEvent.js';
+import { EVENT_TYPES } from '../events/eventTypes.js';
+
+export interface ICargoReconciliationService {
+  /**
+   * Record a cargo scan (load/unload/checkpoint) at a stop and evaluate for discrepancies.
+   */
+  recordCargoScan(scan: CreateCargoScanDTO): Promise<CargoScanResult>;
+
+  /**
+   * Reconcile cargo when a stop is completed.
+   * Compares expected units (from orders assigned to this stop) against scanned units.
+   * Creates discrepancies for missing or unexpected cargo.
+   */
+  reconcileStopCompletion(shipmentStopId: string): Promise<ReconciliationResult>;
+
+  /**
+   * Check for cargo left on vehicle after last stop is completed.
+   */
+  checkLeftOnVehicle(shipmentId: string): Promise<ReconciliationResult>;
+
+  /**
+   * Auto-mark trackable units as delivered at a stop when the stop is completed
+   * and no explicit scans exist (bulk operation for geofence/auto arrivals).
+   */
+  autoReconcileStop(shipmentStopId: string, method: string): Promise<number>;
+}
+
+export interface CargoScanResult {
+  scan: any;
+  isExpected: boolean;
+  discrepancy: any | null;
+}
+
+export interface ReconciliationResult {
+  stopId?: string;
+  shipmentId: string;
+  missingUnits: string[];
+  unexpectedUnits: string[];
+  leftOnVehicle: string[];
+  discrepanciesCreated: number;
+}
+
+export class CargoReconciliationService implements ICargoReconciliationService {
+  constructor(
+    private prisma: PrismaClient,
+    private cargoRepo: ICargoTrackingRepository,
+    private eventBus: IEventBus,
+  ) {}
+
+  async recordCargoScan(scanData: CreateCargoScanDTO): Promise<CargoScanResult> {
+    // Find the stop to determine if this unit is expected here
+    const stop = await this.prisma.shipmentStop.findUnique({
+      where: { id: scanData.shipmentStopId },
+      include: {
+        location: true,
+        orders: {
+          include: { trackableUnits: true },
+        },
+      },
+    });
+
+    if (!stop) {
+      throw new Error('Shipment stop not found');
+    }
+
+    // Get the trackable unit
+    const unit = await this.prisma.trackableUnit.findUnique({
+      where: { id: scanData.trackableUnitId },
+      include: {
+        order: {
+          include: { deliveryStop: { include: { location: true } } },
+        },
+      },
+    });
+
+    if (!unit) {
+      throw new Error('Trackable unit not found');
+    }
+
+    // Determine if this unit is expected at this stop
+    const expectedUnitIds = new Set<string>();
+    for (const order of stop.orders) {
+      for (const tu of order.trackableUnits) {
+        expectedUnitIds.add(tu.id);
+      }
+    }
+    const isExpected = expectedUnitIds.has(scanData.trackableUnitId);
+
+    // Create the scan record
+    const scan = await this.cargoRepo.createScan({
+      ...scanData,
+      expected: isExpected,
+    });
+
+    let discrepancy: any = null;
+
+    // If this is an unload scan and the unit is NOT expected here, create a discrepancy
+    if (scanData.scanType === 'unload' && !isExpected) {
+      const expectedStopId = unit.order.deliveryStopId;
+      const expectedStop = unit.order.deliveryStop;
+
+      // Determine discrepancy type
+      let discrepancyType: CreateCargoDiscrepancyDTO['discrepancyType'];
+      if (expectedStopId) {
+        // Check if this stop comes before or after the expected stop
+        const expectedStopRecord = await this.prisma.shipmentStop.findUnique({
+          where: { id: expectedStopId },
+        });
+        if (expectedStopRecord && stop.sequenceNumber < expectedStopRecord.sequenceNumber) {
+          discrepancyType = 'misdrop_early';
+        } else {
+          discrepancyType = 'misdrop_late';
+        }
+      } else {
+        discrepancyType = 'wrong_destination';
+      }
+
+      const expectedLocationName = expectedStop?.location?.name || 'unknown';
+      const actualLocationName = stop.location?.name || 'unknown';
+
+      discrepancy = await this.cargoRepo.createDiscrepancy({
+        shipmentId: scanData.shipmentId,
+        trackableUnitId: scanData.trackableUnitId,
+        discrepancyType,
+        severity: 'high',
+        expectedStopId: expectedStopId || undefined,
+        actualStopId: scanData.shipmentStopId,
+        detectedBy: scanData.scannedBy || 'system',
+        description: `${unit.unitType} "${unit.identifier}" unloaded at ${actualLocationName} but was expected at ${expectedLocationName}`,
+      });
+
+      // Publish event for misdrop
+      await this.publishCargoEvent(
+        EVENT_TYPES.CARGO_MISDROP_DETECTED,
+        scanData.shipmentId,
+        scanData.trackableUnitId,
+        {
+          unitIdentifier: unit.identifier,
+          unitType: unit.unitType,
+          discrepancyType,
+          expectedStop: expectedLocationName,
+          actualStop: actualLocationName,
+          orderId: unit.orderId,
+          orderNumber: unit.order.orderNumber,
+        },
+      );
+    }
+
+    // Update unit location if unloading
+    if (scanData.scanType === 'unload') {
+      await this.cargoRepo.updateUnitLocation(scanData.trackableUnitId, scanData.shipmentStopId);
+    }
+
+    return { scan, isExpected, discrepancy };
+  }
+
+  async reconcileStopCompletion(shipmentStopId: string): Promise<ReconciliationResult> {
+    const stop = await this.prisma.shipmentStop.findUnique({
+      where: { id: shipmentStopId },
+      include: {
+        location: true,
+        shipment: true,
+        orders: {
+          include: {
+            trackableUnits: true,
+          },
+        },
+        cargoScans: {
+          where: { scanType: 'unload' },
+        },
+      },
+    });
+
+    if (!stop) {
+      throw new Error('Shipment stop not found');
+    }
+
+    const result: ReconciliationResult = {
+      stopId: shipmentStopId,
+      shipmentId: stop.shipmentId,
+      missingUnits: [],
+      unexpectedUnits: [],
+      leftOnVehicle: [],
+      discrepanciesCreated: 0,
+    };
+
+    // Expected unit IDs at this stop (from assigned orders)
+    const expectedUnitIds = new Set<string>();
+    const unitMap = new Map<string, any>();
+    for (const order of stop.orders) {
+      for (const unit of order.trackableUnits) {
+        expectedUnitIds.add(unit.id);
+        unitMap.set(unit.id, { ...unit, orderNumber: order.orderNumber });
+      }
+    }
+
+    // Scanned unit IDs at this stop
+    const scannedUnitIds = new Set(stop.cargoScans.map((s) => s.trackableUnitId));
+
+    // If no scans were recorded but the stop has been completed, auto-mark units as delivered
+    // (This happens for geofence/auto completions where no manual scanning occurs)
+    if (scannedUnitIds.size === 0 && expectedUnitIds.size > 0) {
+      // In auto mode, assume all expected units were delivered correctly
+      for (const unitId of expectedUnitIds) {
+        await this.cargoRepo.updateUnitLocation(unitId, shipmentStopId);
+      }
+      return result;
+    }
+
+    // Find units expected but NOT scanned (missing)
+    for (const unitId of expectedUnitIds) {
+      if (!scannedUnitIds.has(unitId)) {
+        result.missingUnits.push(unitId);
+        const unit = unitMap.get(unitId);
+
+        const disc = await this.cargoRepo.createDiscrepancy({
+          shipmentId: stop.shipmentId,
+          trackableUnitId: unitId,
+          discrepancyType: 'missing_at_stop',
+          severity: 'high',
+          expectedStopId: shipmentStopId,
+          detectedBy: 'system',
+          description: `${unit?.unitType || 'Unit'} "${unit?.identifier || unitId}" expected at ${stop.location.name} but was not scanned on unload`,
+        });
+        result.discrepanciesCreated++;
+
+        await this.publishCargoEvent(
+          EVENT_TYPES.CARGO_MISSING_AT_STOP,
+          stop.shipmentId,
+          unitId,
+          {
+            unitIdentifier: unit?.identifier,
+            unitType: unit?.unitType,
+            stopName: stop.location.name,
+            orderNumber: unit?.orderNumber,
+          },
+        );
+      }
+    }
+
+    // Find units scanned but NOT expected (unexpected deliveries / misdrops from elsewhere)
+    for (const scanUnitId of scannedUnitIds) {
+      if (!expectedUnitIds.has(scanUnitId)) {
+        result.unexpectedUnits.push(scanUnitId);
+        // Discrepancy already created during the scan itself (in recordCargoScan)
+      }
+    }
+
+    return result;
+  }
+
+  async checkLeftOnVehicle(shipmentId: string): Promise<ReconciliationResult> {
+    const result: ReconciliationResult = {
+      shipmentId,
+      missingUnits: [],
+      unexpectedUnits: [],
+      leftOnVehicle: [],
+      discrepanciesCreated: 0,
+    };
+
+    // Get all stops and all trackable units for this shipment
+    const stops = await this.prisma.shipmentStop.findMany({
+      where: { shipmentId },
+      orderBy: { sequenceNumber: 'asc' },
+    });
+
+    const allCompleted = stops.every((s) => s.status === 'completed' || s.status === 'skipped');
+    if (!allCompleted) {
+      return result; // Not all stops done yet
+    }
+
+    // Get all orders for this shipment with their trackable units
+    const orderShipments = await this.prisma.orderShipment.findMany({
+      where: { shipmentId },
+      include: {
+        order: {
+          include: {
+            trackableUnits: true,
+          },
+        },
+      },
+    });
+
+    for (const os of orderShipments) {
+      for (const unit of os.order.trackableUnits) {
+        // If unit has no current stop, it's still "on the vehicle"
+        if (!(unit as any).currentStopId) {
+          result.leftOnVehicle.push(unit.id);
+
+          await this.cargoRepo.createDiscrepancy({
+            shipmentId,
+            trackableUnitId: unit.id,
+            discrepancyType: 'left_on_vehicle',
+            severity: 'critical',
+            expectedStopId: os.order.deliveryStopId || undefined,
+            detectedBy: 'system',
+            description: `${unit.unitType} "${unit.identifier}" was never confirmed delivered — may still be on the vehicle`,
+          });
+          result.discrepanciesCreated++;
+
+          await this.publishCargoEvent(
+            EVENT_TYPES.CARGO_LEFT_ON_VEHICLE,
+            shipmentId,
+            unit.id,
+            {
+              unitIdentifier: unit.identifier,
+              unitType: unit.unitType,
+              orderId: unit.orderId,
+              orderNumber: os.order.orderNumber,
+            },
+          );
+        }
+      }
+    }
+
+    return result;
+  }
+
+  async autoReconcileStop(shipmentStopId: string, method: string): Promise<number> {
+    const stop = await this.prisma.shipmentStop.findUnique({
+      where: { id: shipmentStopId },
+      include: {
+        shipment: true,
+        location: true,
+        orders: {
+          include: { trackableUnits: true },
+        },
+      },
+    });
+
+    if (!stop) return 0;
+
+    let count = 0;
+    for (const order of stop.orders) {
+      for (const unit of order.trackableUnits) {
+        // Mark unit as being at this stop
+        await this.cargoRepo.updateUnitLocation(unit.id, shipmentStopId);
+
+        // Create an automatic scan record
+        await this.cargoRepo.createScan({
+          trackableUnitId: unit.id,
+          shipmentStopId,
+          shipmentId: stop.shipmentId,
+          scanType: 'unload',
+          scanMethod: method === 'geofence_iot' ? 'iot' : method === 'geofence' ? 'geofence' : 'manual',
+          scannedBy: `system:${method}`,
+          expected: true,
+        });
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  private async publishCargoEvent(
+    eventType: string,
+    shipmentId: string,
+    trackableUnitId: string,
+    payload: any,
+  ): Promise<void> {
+    const event: DomainEvent = {
+      id: randomUUID(),
+      type: eventType,
+      timestamp: new Date().toISOString(),
+      orgId: 'default',
+      actorId: null,
+      entityType: 'trackable_unit',
+      entityId: trackableUnitId,
+      payload: {
+        ...payload,
+        shipmentId,
+        trackableUnitId,
+      },
+      metadata: {
+        correlationId: randomUUID(),
+        source: 'system',
+        schemaVersion: 1,
+      },
+    };
+
+    try {
+      await this.eventBus.publish(event);
+    } catch (err) {
+      // Log but don't fail the scan — event publishing is best-effort
+      console.error('Failed to publish cargo event:', err);
+    }
+  }
+}

--- a/backend/src/services/OrderDeliveryService.ts
+++ b/backend/src/services/OrderDeliveryService.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { ICargoReconciliationService } from './CargoReconciliationService.js';
 
 export interface DeliveryStatusUpdate {
   orderId: string;
@@ -27,7 +28,16 @@ export interface IOrderDeliveryService {
 }
 
 export class OrderDeliveryService implements IOrderDeliveryService {
+  private cargoReconciliation: ICargoReconciliationService | null = null;
+
   constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Set the cargo reconciliation service (injected after construction to avoid circular deps)
+   */
+  setCargoReconciliationService(service: ICargoReconciliationService): void {
+    this.cargoReconciliation = service;
+  }
 
   /**
    * Update order delivery status
@@ -267,6 +277,27 @@ export class OrderDeliveryService implements IOrderDeliveryService {
             },
           }
         });
+      }
+
+      // Cargo reconciliation: auto-record scans and reconcile for misdrop detection
+      if (this.cargoReconciliation) {
+        try {
+          await this.cargoReconciliation.autoReconcileStop(shipmentStopId, method);
+          await this.cargoReconciliation.reconcileStopCompletion(shipmentStopId);
+
+          // If this was the last stop, check for cargo left on vehicle
+          const allStops = await this.prisma.shipmentStop.findMany({
+            where: { shipmentId: stop.shipmentId },
+          });
+          const allCompleted = allStops.every(
+            (s) => s.id === shipmentStopId || s.status === 'completed' || s.status === 'skipped'
+          );
+          if (allCompleted) {
+            await this.cargoReconciliation.checkLeftOnVehicle(stop.shipmentId);
+          }
+        } catch (err) {
+          console.error('[OrderDeliveryService] Cargo reconciliation failed (non-blocking):', err);
+        }
       }
 
       return updateResult.count;

--- a/frontend/src/vnext-design/VNextShipmentDetail.tsx
+++ b/frontend/src/vnext-design/VNextShipmentDetail.tsx
@@ -223,6 +223,466 @@ function TelemetryTab({ shipmentId }: { shipmentId: string }) {
   );
 }
 
+// ─── Cargo Tab ─────────────────────────────────────────────────────────────
+
+interface CargoManifest {
+  shipmentId: string;
+  stops: Array<{
+    stopId: string;
+    sequenceNumber: number;
+    locationName: string;
+    stopType: string;
+    status: string;
+    expectedUnits: ManifestUnit[];
+    scannedUnits: ManifestUnit[];
+    discrepancies: CargoDiscrepancy[];
+  }>;
+  unassignedUnits: ManifestUnit[];
+  totalExpected: number;
+  totalScanned: number;
+  totalDiscrepancies: number;
+}
+
+interface ManifestUnit {
+  id: string;
+  identifier: string;
+  unitType: string;
+  barcode: string | null;
+  condition: string;
+  currentStopId: string | null;
+  orderId: string;
+  orderNumber: string;
+  lineItemCount: number;
+  lastScannedAt: string | null;
+}
+
+interface CargoDiscrepancy {
+  id: string;
+  discrepancyType: string;
+  severity: string;
+  status: string;
+  description: string;
+  detectedAt: string;
+  resolvedAt: string | null;
+  resolution: string | null;
+  trackableUnit: { identifier: string; unitType: string; order?: { orderNumber: string } };
+  expectedStop?: { location: { name: string } };
+  actualStop?: { location: { name: string } };
+}
+
+const discrepancyTypeLabels: Record<string, string> = {
+  misdrop_early: 'Dropped Too Early',
+  misdrop_late: 'Dropped Too Late',
+  missing_at_stop: 'Missing at Stop',
+  unexpected_at_stop: 'Unexpected at Stop',
+  left_on_vehicle: 'Left on Vehicle',
+  damaged: 'Damaged',
+  wrong_destination: 'Wrong Destination',
+};
+
+const severityChip: Record<string, string> = {
+  critical: 'vn-chip vn-chip-error',
+  high: 'vn-chip vn-chip-error',
+  medium: 'vn-chip vn-chip-warning',
+  low: 'vn-chip vn-chip-info',
+};
+
+const conditionChip: Record<string, string> = {
+  good: 'vn-chip vn-chip-success',
+  damaged: 'vn-chip vn-chip-error',
+  lost: 'vn-chip vn-chip-error',
+  unknown: 'vn-chip vn-chip-warning',
+};
+
+const stopStatusIcon: Record<string, { icon: string; color: string }> = {
+  pending: { icon: 'schedule', color: 'var(--on-surface-variant)' },
+  arrived: { icon: 'location_on', color: 'var(--info)' },
+  in_progress: { icon: 'local_shipping', color: 'var(--warning)' },
+  completed: { icon: 'check_circle', color: 'var(--success)' },
+  skipped: { icon: 'skip_next', color: 'var(--on-surface-variant)' },
+};
+
+function CargoTab({ shipmentId }: { shipmentId: string }) {
+  const [manifest, setManifest] = useState<CargoManifest | null>(null);
+  const [discrepancies, setDiscrepancies] = useState<CargoDiscrepancy[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [resolving, setResolving] = useState<string | null>(null);
+
+  const loadData = useCallback(() => {
+    if (!shipmentId) return;
+    setLoading(true);
+    Promise.all([
+      fetch(`${API_URL}/api/v1/shipments/${shipmentId}/cargo-manifest`).then(r => r.json()),
+      fetch(`${API_URL}/api/v1/shipments/${shipmentId}/cargo-discrepancies`).then(r => r.json()),
+    ])
+      .then(([manifestRes, discRes]) => {
+        if (manifestRes.error) throw new Error(manifestRes.error);
+        setManifest(manifestRes.data);
+        setDiscrepancies(discRes.data || []);
+        setError('');
+      })
+      .catch(err => setError(err.message || 'Failed to load cargo data'))
+      .finally(() => setLoading(false));
+  }, [shipmentId]);
+
+  useEffect(() => { loadData(); }, [loadData]);
+
+  const handleResolve = async (discId: string) => {
+    const resolution = prompt('Resolution notes:');
+    if (!resolution) return;
+    setResolving(discId);
+    try {
+      const res = await fetch(`${API_URL}/api/v1/cargo-discrepancies/${discId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'resolved', resolution }),
+      });
+      const json = await res.json();
+      if (json.error) throw new Error(json.error);
+      loadData();
+    } catch (err: any) {
+      alert(`Failed to resolve: ${err.message}`);
+    } finally {
+      setResolving(null);
+    }
+  };
+
+  const handleInvestigate = async (discId: string) => {
+    try {
+      await fetch(`${API_URL}/api/v1/cargo-discrepancies/${discId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'investigating' }),
+      });
+      loadData();
+    } catch { /* ignore */ }
+  };
+
+  if (loading) {
+    return <div className="vn-empty"><span className="material-icons" style={{ animation: 'spin 1s linear infinite' }}>refresh</span><h3>Loading cargo data...</h3></div>;
+  }
+
+  if (error) {
+    return <div className="vn-alert vn-alert-error"><span className="material-icons">error</span><div className="vn-alert-content">{error}</div></div>;
+  }
+
+  if (!manifest || (manifest.totalExpected === 0 && manifest.unassignedUnits.length === 0)) {
+    return (
+      <div className="vn-card">
+        <div className="vn-card-body" style={{ textAlign: 'center', padding: 48 }}>
+          <span className="material-icons" style={{ fontSize: 48, opacity: 0.3, display: 'block', marginBottom: 12, color: 'var(--on-surface-variant)' }}>inventory_2</span>
+          <h3 style={{ color: 'var(--on-surface-variant)', margin: 0 }}>No trackable cargo units</h3>
+          <p style={{ color: 'var(--on-surface-variant)', fontSize: 13, marginTop: 8 }}>
+            Add trackable units (pallets, totes, boxes) to orders assigned to this shipment to enable cargo tracking.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const openDiscrepancies = discrepancies.filter(d => d.status === 'open' || d.status === 'investigating');
+
+  return (
+    <>
+      {/* Summary Stats */}
+      <div className="vn-stats-row" style={{ marginBottom: 24 }}>
+        <div className="vn-stat-card">
+          <div className="vn-stat-icon" style={{ background: 'var(--primary-container)', color: 'var(--primary)' }}>
+            <span className="material-icons">inventory_2</span>
+          </div>
+          <div className="vn-stat-content">
+            <span className="vn-stat-value">{manifest.totalExpected}</span>
+            <span className="vn-stat-label">Expected Units</span>
+          </div>
+        </div>
+        <div className="vn-stat-card">
+          <div className="vn-stat-icon" style={{ background: 'var(--success-container, rgba(0,200,83,0.1))', color: 'var(--success)' }}>
+            <span className="material-icons">qr_code_scanner</span>
+          </div>
+          <div className="vn-stat-content">
+            <span className="vn-stat-value">{manifest.totalScanned}</span>
+            <span className="vn-stat-label">Scanned / Confirmed</span>
+          </div>
+        </div>
+        <div className="vn-stat-card">
+          <div className="vn-stat-icon" style={{ background: openDiscrepancies.length > 0 ? 'var(--error-container, rgba(255,0,0,0.1))' : 'var(--surface-container)', color: openDiscrepancies.length > 0 ? 'var(--error)' : 'var(--on-surface-variant)' }}>
+            <span className="material-icons">warning</span>
+          </div>
+          <div className="vn-stat-content">
+            <span className="vn-stat-value">{openDiscrepancies.length}</span>
+            <span className="vn-stat-label">Open Issues</span>
+          </div>
+        </div>
+        <div className="vn-stat-card">
+          <div className="vn-stat-icon" style={{ background: 'var(--primary-container)', color: 'var(--primary)' }}>
+            <span className="material-icons">pin_drop</span>
+          </div>
+          <div className="vn-stat-content">
+            <span className="vn-stat-value">{manifest.stops.length}</span>
+            <span className="vn-stat-label">Delivery Stops</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Discrepancy Alerts */}
+      {openDiscrepancies.length > 0 && (
+        <div className="vn-card" style={{ marginBottom: 24, border: '1px solid var(--error)', background: 'var(--error-container, rgba(255,0,0,0.04))' }}>
+          <div className="vn-card-header" style={{ borderBottom: '1px solid var(--error)' }}>
+            <h2 style={{ color: 'var(--error)', display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span className="material-icons">report_problem</span>
+              Cargo Issues ({openDiscrepancies.length})
+            </h2>
+          </div>
+          <div className="vn-card-body" style={{ padding: 0 }}>
+            {openDiscrepancies.map((disc) => (
+              <div key={disc.id} style={{
+                padding: '12px 16px',
+                borderBottom: '1px solid var(--outline-variant)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+              }}>
+                <span className="material-icons" style={{
+                  color: disc.severity === 'critical' || disc.severity === 'high' ? 'var(--error)' : 'var(--warning)',
+                  fontSize: 20,
+                  flexShrink: 0,
+                }}>
+                  {disc.discrepancyType === 'left_on_vehicle' ? 'local_shipping' :
+                   disc.discrepancyType === 'missing_at_stop' ? 'search_off' :
+                   disc.discrepancyType.startsWith('misdrop') ? 'wrong_location' : 'error'}
+                </span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                    <span style={{ fontWeight: 600, fontSize: 13 }}>
+                      {discrepancyTypeLabels[disc.discrepancyType] || disc.discrepancyType}
+                    </span>
+                    <span className={severityChip[disc.severity] || 'vn-chip'} style={{ fontSize: 11 }}>{disc.severity}</span>
+                    {disc.status === 'investigating' && (
+                      <span className="vn-chip vn-chip-warning" style={{ fontSize: 11 }}>Investigating</span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 12, color: 'var(--on-surface-variant)', marginTop: 2 }}>
+                    {disc.description}
+                  </div>
+                  <div style={{ fontSize: 11, color: 'var(--on-surface-variant)', marginTop: 2 }}>
+                    Detected {new Date(disc.detectedAt).toLocaleString()}
+                  </div>
+                </div>
+                <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+                  {disc.status === 'open' && (
+                    <button
+                      className="vn-btn vn-btn-outline vn-btn-sm"
+                      onClick={() => handleInvestigate(disc.id)}
+                      style={{ fontSize: 12 }}
+                    >
+                      Investigate
+                    </button>
+                  )}
+                  <button
+                    className="vn-btn vn-btn-primary vn-btn-sm"
+                    onClick={() => handleResolve(disc.id)}
+                    disabled={resolving === disc.id}
+                    style={{ fontSize: 12 }}
+                  >
+                    {resolving === disc.id ? 'Resolving...' : 'Resolve'}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Per-Stop Cargo Manifest */}
+      {manifest.stops.map((stop) => {
+        const statusInfo = stopStatusIcon[stop.status] || stopStatusIcon.pending;
+        const hasIssues = stop.discrepancies.filter(d => d.status !== 'resolved' && d.status !== 'dismissed').length > 0;
+        const allDelivered = stop.status === 'completed' && stop.expectedUnits.length > 0;
+
+        return (
+          <div key={stop.stopId} className="vn-card" style={{
+            marginBottom: 16,
+            border: hasIssues ? '1px solid var(--error)' : undefined,
+          }}>
+            <div className="vn-card-header">
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span className="material-icons" style={{ color: statusInfo.color, fontSize: 20 }}>{statusInfo.icon}</span>
+                <div>
+                  <h2 style={{ margin: 0, fontSize: 15 }}>
+                    Stop {stop.sequenceNumber} — {stop.locationName}
+                  </h2>
+                  <div style={{ fontSize: 12, color: 'var(--on-surface-variant)', marginTop: 2 }}>
+                    {stop.stopType} · {stop.status}
+                    {stop.expectedUnits.length > 0 && ` · ${stop.expectedUnits.length} unit${stop.expectedUnits.length !== 1 ? 's' : ''} expected`}
+                  </div>
+                </div>
+              </div>
+              {allDelivered && !hasIssues && (
+                <span className="vn-chip vn-chip-success" style={{ fontSize: 11 }}>
+                  <span className="material-icons" style={{ fontSize: 14, marginRight: 2 }}>check</span>
+                  All Delivered
+                </span>
+              )}
+              {hasIssues && (
+                <span className="vn-chip vn-chip-error" style={{ fontSize: 11 }}>
+                  <span className="material-icons" style={{ fontSize: 14, marginRight: 2 }}>warning</span>
+                  Issues Detected
+                </span>
+              )}
+            </div>
+
+            {stop.expectedUnits.length > 0 && (
+              <div className="vn-card-body vn-card-flush">
+                <div className="vn-table-wrap">
+                  <table className="vn-table">
+                    <thead>
+                      <tr>
+                        <th>Unit</th>
+                        <th>Type</th>
+                        <th>Order</th>
+                        <th>Items</th>
+                        <th>Condition</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {stop.expectedUnits.map((unit) => {
+                        const isAtThisStop = unit.currentStopId === stop.stopId;
+                        const isScanned = stop.scannedUnits.some(s => s.id === unit.id);
+                        const unitDisc = stop.discrepancies.find(
+                          (d: any) => d.trackableUnitId === unit.id && d.status !== 'resolved' && d.status !== 'dismissed'
+                        );
+                        let statusLabel = 'Pending';
+                        let statusClass = 'vn-chip vn-chip-secondary';
+                        if (isAtThisStop || isScanned) {
+                          statusLabel = 'Delivered';
+                          statusClass = 'vn-chip vn-chip-success';
+                        } else if (stop.status === 'completed') {
+                          statusLabel = isScanned ? 'Delivered' : 'Not confirmed';
+                          statusClass = isScanned ? 'vn-chip vn-chip-success' : 'vn-chip vn-chip-warning';
+                        } else if (stop.status === 'arrived' || stop.status === 'in_progress') {
+                          statusLabel = 'In transit';
+                          statusClass = 'vn-chip vn-chip-info';
+                        }
+                        if (unitDisc) {
+                          statusLabel = discrepancyTypeLabels[(unitDisc as any).discrepancyType] || 'Issue';
+                          statusClass = 'vn-chip vn-chip-error';
+                        }
+
+                        return (
+                          <tr key={unit.id}>
+                            <td>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                                <span className="material-icons" style={{ fontSize: 18, color: 'var(--on-surface-variant)' }}>
+                                  {unit.unitType === 'pallet' ? 'pallet' :
+                                   unit.unitType === 'box' ? 'inventory_2' :
+                                   unit.unitType === 'tote' ? 'shopping_basket' : 'widgets'}
+                                </span>
+                                <div>
+                                  <div style={{ fontWeight: 500, fontSize: 13 }}>{unit.identifier}</div>
+                                  {unit.barcode && <div style={{ fontSize: 11, color: 'var(--on-surface-variant)' }}>{unit.barcode}</div>}
+                                </div>
+                              </div>
+                            </td>
+                            <td style={{ fontSize: 13, textTransform: 'capitalize' }}>{unit.unitType}</td>
+                            <td>
+                              <Link to={`/orders/${unit.orderId}`} style={{ color: 'var(--primary)', fontSize: 13, textDecoration: 'none' }}>
+                                {unit.orderNumber}
+                              </Link>
+                            </td>
+                            <td style={{ fontSize: 13 }}>{unit.lineItemCount}</td>
+                            <td><span className={conditionChip[unit.condition] || 'vn-chip'} style={{ fontSize: 11 }}>{unit.condition}</span></td>
+                            <td><span className={statusClass} style={{ fontSize: 11 }}>{statusLabel}</span></td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {stop.expectedUnits.length === 0 && (
+              <div className="vn-card-body" style={{ textAlign: 'center', padding: 24, color: 'var(--on-surface-variant)', fontSize: 13 }}>
+                No cargo units assigned to this stop
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {/* Unassigned Units */}
+      {manifest.unassignedUnits.length > 0 && (
+        <div className="vn-card" style={{ marginBottom: 16, border: '1px solid var(--warning)' }}>
+          <div className="vn-card-header">
+            <h2 style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 15 }}>
+              <span className="material-icons" style={{ color: 'var(--warning)', fontSize: 20 }}>help_outline</span>
+              Unassigned Cargo ({manifest.unassignedUnits.length})
+            </h2>
+          </div>
+          <div className="vn-card-body" style={{ fontSize: 13, color: 'var(--on-surface-variant)' }}>
+            These trackable units are on this shipment but not assigned to a delivery stop.
+          </div>
+          <div className="vn-card-body vn-card-flush">
+            <div className="vn-table-wrap">
+              <table className="vn-table">
+                <thead>
+                  <tr><th>Unit</th><th>Type</th><th>Order</th><th>Items</th><th>Condition</th></tr>
+                </thead>
+                <tbody>
+                  {manifest.unassignedUnits.map((unit) => (
+                    <tr key={unit.id}>
+                      <td style={{ fontWeight: 500, fontSize: 13 }}>{unit.identifier}</td>
+                      <td style={{ fontSize: 13, textTransform: 'capitalize' }}>{unit.unitType}</td>
+                      <td>
+                        <Link to={`/orders/${unit.orderId}`} style={{ color: 'var(--primary)', fontSize: 13, textDecoration: 'none' }}>
+                          {unit.orderNumber}
+                        </Link>
+                      </td>
+                      <td style={{ fontSize: 13 }}>{unit.lineItemCount}</td>
+                      <td><span className={conditionChip[unit.condition] || 'vn-chip'} style={{ fontSize: 11 }}>{unit.condition}</span></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Resolved Discrepancies History */}
+      {discrepancies.filter(d => d.status === 'resolved' || d.status === 'dismissed').length > 0 && (
+        <div className="vn-card">
+          <div className="vn-card-header">
+            <h2 style={{ fontSize: 15 }}>Resolved Issues</h2>
+          </div>
+          <div className="vn-card-body vn-card-flush">
+            <div className="vn-table-wrap">
+              <table className="vn-table">
+                <thead>
+                  <tr><th>Issue</th><th>Unit</th><th>Status</th><th>Resolution</th><th>Resolved</th></tr>
+                </thead>
+                <tbody>
+                  {discrepancies.filter(d => d.status === 'resolved' || d.status === 'dismissed').map((disc) => (
+                    <tr key={disc.id}>
+                      <td style={{ fontSize: 13 }}>{discrepancyTypeLabels[disc.discrepancyType] || disc.discrepancyType}</td>
+                      <td style={{ fontSize: 13 }}>{disc.trackableUnit?.identifier || '—'}</td>
+                      <td><span className="vn-chip vn-chip-success" style={{ fontSize: 11 }}>{disc.status}</span></td>
+                      <td style={{ fontSize: 12, color: 'var(--on-surface-variant)' }}>{disc.resolution || '—'}</td>
+                      <td style={{ fontSize: 12 }}>{disc.resolvedAt ? new Date(disc.resolvedAt).toLocaleString() : '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
 export default function VNextShipmentDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -468,6 +928,10 @@ export default function VNextShipmentDetail() {
             <button className={`vn-tab ${activeTab === 'documents' ? 'active' : ''}`} onClick={() => setActiveTab('documents')}>Documents</button>
             <button className={`vn-tab ${activeTab === 'financials' ? 'active' : ''}`} onClick={() => setActiveTab('financials')}>Financials</button>
             <button className={`vn-tab ${activeTab === 'notes' ? 'active' : ''}`} onClick={() => setActiveTab('notes')}>Notes</button>
+            <button className={`vn-tab ${activeTab === 'cargo' ? 'active' : ''}`} onClick={() => setActiveTab('cargo')}>
+              <span className="material-icons" style={{ fontSize: 16, marginRight: 4, verticalAlign: 'middle' }}>inventory_2</span>
+              Cargo
+            </button>
             <button className={`vn-tab ${activeTab === 'telemetry' ? 'active' : ''}`} onClick={() => setActiveTab('telemetry')}>
               <span className="material-icons" style={{ fontSize: 16, marginRight: 4, verticalAlign: 'middle' }}>thermostat</span>
               Telemetry
@@ -617,6 +1081,10 @@ export default function VNextShipmentDetail() {
                 </div>
               </div>
             </div>
+          )}
+
+          {activeTab === 'cargo' && (
+            <CargoTab shipmentId={id!} />
           )}
 
           {activeTab === 'telemetry' && (


### PR DESCRIPTION
Tracks the lowest-level cargo units (pallets, totes, boxes) through
multi-stop shipments, detecting when items are dropped at the wrong
location (too early, too late, or left on vehicle). When a stop is
completed, the system reconciles expected vs actual cargo and raises
discrepancy issues with notifications.

Backend:
- New Prisma models: CargoScan (physical confirmation at stops),
  CargoDiscrepancy (misdrop/missing/left-on-vehicle tracking)
- TrackableUnit gains currentStopId, condition, and lastScannedAt
- CargoTrackingRepository: manifest queries, scan/discrepancy CRUD
- CargoReconciliationService: misdrop detection on scan, stop
  reconciliation, left-on-vehicle checks after final stop
- Cargo event types (misdrop_detected, missing_at_stop,
  left_on_vehicle, discrepancy_resolved) with in-app notifications
- REST API: cargo-manifest, cargo-scans, cargo-discrepancies,
  reconcile-cargo, check-left-on-vehicle endpoints
- OrderDeliveryService integration: auto-reconciles on stop completion

Frontend:
- Cargo tab on VNext Shipment Detail with per-stop manifest view
  showing expected vs scanned units, condition, and delivery status
- Discrepancy alert panel with investigate/resolve actions
- Summary stats, unassigned cargo warnings, resolved issues history

https://claude.ai/code/session_01AZUofu1oDVfWXcmcDCqZzS