### PR TITLE
feat: implement EDI 214 (Shipment Status Message) support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ The EDI system uses a **unified Trading Partner model** (`TradingPartner`) that 
 | 204 | Motor Carrier Load Tender | Outbound | Active |
 | 990 | Response to Load Tender | Inbound | Active |
 | 997 | Functional Acknowledgment | Both | Active |
-| 214 | Shipment Status | Both | Planned |
+| 214 | Shipment Status | Both | Active |
 | 210 | Freight Invoice | Inbound | Planned |
 
 ### EDI Flow — How It Works
@@ -132,8 +132,12 @@ The EDI system uses a **unified Trading Partner model** (`TradingPartner`) that 
 - `backend/src/services/EDI997Service.ts` — Functional Acknowledgment generator
 - `backend/src/services/EDI850ParseService.ts` — Purchase Order parser
 - `backend/src/services/EDI856Service.ts` — Advance Ship Notice generator
+- `backend/src/services/EDI214ParseService.ts` — EDI 214 Shipment Status parser (inbound)
+- `backend/src/services/EDI214Service.ts` — EDI 214 Shipment Status generator (outbound)
+- `backend/src/services/edi214StatusMapping.ts` — AT7 status code to internal status mapping
 - `backend/src/routes/tradingPartners.ts` — API routes for partner management
 - `backend/src/routes/ediTender.ts` — EDI 204 preview and 990 inbound endpoints
+- `backend/src/routes/edi214.ts` — EDI 214 inbound, generate, and preview endpoints
 - `edi-collector/src/collector.ts` — SFTP polling with multi-type routing
 - `frontend/src/pages/TradingPartners.tsx` — Partner management UI (Integrations app)
 

--- a/backend/src/__tests__/edi214ParseService.test.ts
+++ b/backend/src/__tests__/edi214ParseService.test.ts
@@ -1,0 +1,161 @@
+import { EDI214ParseService } from '../services/EDI214ParseService.js';
+
+describe('EDI214ParseService', () => {
+  const parser = new EDI214ParseService();
+
+  const VALID_214 = [
+    'ISA*00*          *00*          *ZZ*CARRIER        *ZZ*OPENTMS        *260411*1430*U*00401*000000001*0*P*:~',
+    'GS*QM*CARRIER*OPENTMS*20260411*1430*1*X*004010~',
+    'ST*214*0001~',
+    'B10*SHP-001*ABCD*PRO123~',
+    'L11*REF-456*SI~',
+    'AT7*AF***  *20260411*0800*LT~',
+    'MS1*CHICAGO*IL*US~',
+    'AT8*G*L*15000*10~',
+    'SE*8*0001~',
+    'GE*1*1~',
+    'IEA*1*000000001~',
+  ].join('\n');
+
+  it('should parse a valid 214 with B10, AT7, MS1, AT8', () => {
+    const result = parser.parseEDI214(VALID_214);
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.shipmentReference).toBe('SHP-001');
+    expect(result.carrierScac).toBe('ABCD');
+    expect(result.proNumber).toBe('PRO123');
+    expect(result.statusDetails).toHaveLength(1);
+    expect(result.statusDetails[0].statusCode).toBe('AF');
+    expect(result.statusDetails[0].city).toBe('CHICAGO');
+    expect(result.statusDetails[0].state).toBe('IL');
+    expect(result.statusDetails[0].country).toBe('US');
+    expect(result.statusDetails[0].date).toBe('20260411');
+    expect(result.statusDetails[0].time).toBe('0800');
+    expect(result.referenceNumbers).toHaveLength(1);
+    expect(result.referenceNumbers[0]).toEqual({ qualifier: 'SI', number: 'REF-456' });
+    expect(result.weight).toEqual({ weight: 15000, qualifier: 'G', ladingQuantity: 10 });
+  });
+
+  it('should parse 214 with multiple AT7 status details', () => {
+    const multiStatus = [
+      'ST*214*0001~',
+      'B10*SHP-002*WXYZ*PRO789~',
+      'AT7*AF****20260410*0900*LT~',
+      'MS1*LOS ANGELES*CA*US~',
+      'AT7*X6****20260411*1400*LT~',
+      'AT7*D1****20260412*0800*LT~',
+      'MS1*NEW YORK*NY*US~',
+      'SE*7*0001~',
+    ].join('\n');
+
+    const result = parser.parseEDI214(multiStatus);
+
+    expect(result.success).toBe(true);
+    expect(result.statusDetails).toHaveLength(3);
+
+    // First AT7+MS1 pair
+    expect(result.statusDetails[0].statusCode).toBe('AF');
+    expect(result.statusDetails[0].city).toBe('LOS ANGELES');
+    expect(result.statusDetails[0].state).toBe('CA');
+
+    // Second AT7 without MS1 (flushed when third AT7 arrives)
+    expect(result.statusDetails[1].statusCode).toBe('X6');
+    expect(result.statusDetails[1].city).toBe('');
+
+    // Third AT7+MS1 pair
+    expect(result.statusDetails[2].statusCode).toBe('D1');
+    expect(result.statusDetails[2].city).toBe('NEW YORK');
+    expect(result.statusDetails[2].state).toBe('NY');
+  });
+
+  it('should fail gracefully when B10 is missing', () => {
+    const noB10 = [
+      'ST*214*0001~',
+      'AT7*AF****20260411*0800*LT~',
+      'MS1*CHICAGO*IL*US~',
+      'SE*3*0001~',
+    ].join('\n');
+
+    const result = parser.parseEDI214(noB10);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('Missing carrier SCAC code in B10 segment');
+    expect(result.errors).toContain('Missing shipment reference and pro number in B10 segment');
+  });
+
+  it('should fail when no AT7 status details are found', () => {
+    const noAT7 = [
+      'ST*214*0001~',
+      'B10*SHP-003*ABCD*PRO456~',
+      'SE*2*0001~',
+    ].join('\n');
+
+    const result = parser.parseEDI214(noAT7);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('No AT7 status details found');
+  });
+
+  it('should error when transaction set is not 214', () => {
+    const wrong = [
+      'ST*850*0001~',
+      'B10*SHP-003*ABCD*PRO456~',
+      'AT7*AF****20260411*0800*LT~',
+      'SE*3*0001~',
+    ].join('\n');
+
+    const result = parser.parseEDI214(wrong);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('Transaction set is not 214');
+  });
+
+  it('should handle SCAC fallback from MS3 segment', () => {
+    const ms3Fallback = [
+      'ST*214*0001~',
+      'B10*SHP-004**PRO789~',
+      'MS3*ZZZZ~',
+      'AT7*X1****20260411*1200*LT~',
+      'MS1*DALLAS*TX*US~',
+      'SE*5*0001~',
+    ].join('\n');
+
+    const result = parser.parseEDI214(ms3Fallback);
+
+    expect(result.success).toBe(true);
+    expect(result.carrierScac).toBe('ZZZZ');
+  });
+
+  it('should handle Windows-style line endings', () => {
+    const windowsContent = 'ST*214*0001~\r\nB10*SHP-005*ABCD*PRO111~\r\nAT7*D1****20260411*1600*LT~\r\nMS1*MIAMI*FL*US~\r\nSE*4*0001~\r\n';
+
+    const result = parser.parseEDI214(windowsContent);
+
+    expect(result.success).toBe(true);
+    expect(result.statusDetails[0].statusCode).toBe('D1');
+    expect(result.statusDetails[0].city).toBe('MIAMI');
+  });
+
+  it('should always preserve rawContent', () => {
+    const result = parser.parseEDI214(VALID_214);
+    expect(result.rawContent).toBe(VALID_214);
+  });
+
+  it('should handle AT7 without following MS1', () => {
+    const noMs1 = [
+      'ST*214*0001~',
+      'B10*SHP-006*ABCD*PRO222~',
+      'AT7*OA****20260411*0700*LT~',
+      'SE*3*0001~',
+    ].join('\n');
+
+    const result = parser.parseEDI214(noMs1);
+
+    expect(result.success).toBe(true);
+    expect(result.statusDetails).toHaveLength(1);
+    expect(result.statusDetails[0].statusCode).toBe('OA');
+    expect(result.statusDetails[0].city).toBe('');
+    expect(result.statusDetails[0].state).toBe('');
+  });
+});

--- a/backend/src/__tests__/edi214Service.test.ts
+++ b/backend/src/__tests__/edi214Service.test.ts
@@ -1,0 +1,173 @@
+import { EDI214Service } from '../services/EDI214Service.js';
+
+describe('EDI214Service', () => {
+  const service = new EDI214Service();
+
+  it('should generate a valid EDI 214 document', () => {
+    const ediContent = service.generateEDI214({
+      shipmentReference: 'SHP-001',
+      proNumber: 'PRO123',
+      carrierScac: 'ABCD',
+      statusCode: 'AF',
+      city: 'CHICAGO',
+      state: 'IL',
+      country: 'US',
+      statusDate: new Date('2026-04-11T08:00:00Z'),
+      weight: 15000,
+      weightUnit: 'L',
+      ladingQuantity: 10,
+    }, {
+      senderId: 'OPENTMS',
+      receiverId: 'ABCD',
+      interchangeControlNumber: '000000001',
+    });
+
+    const segments = ediContent.split('\n').map(s => s.replace(/~$/, ''));
+
+    // ISA
+    expect(segments[0]).toMatch(/^ISA\*/);
+    expect(segments[0]).toContain('OPENTMS');
+
+    // GS — must be QM for Shipment Status
+    expect(segments[1]).toMatch(/^GS\*QM\*/);
+    expect(segments[1]).toContain('004010');
+
+    // ST — must be 214
+    expect(segments[2]).toBe('ST*214*0001');
+
+    // B10 — Shipment identification
+    expect(segments[3]).toBe('B10*SHP-001*ABCD*PRO123');
+
+    // L11 — Reference number
+    expect(segments[4]).toBe('L11*SHP-001*SI');
+
+    // AT7 — Status detail
+    const at7 = segments[5];
+    expect(at7).toMatch(/^AT7\*AF\*/);
+    expect(at7).toContain('20260411');
+    expect(at7).toContain('0800');
+    expect(at7).toContain('LT');
+
+    // MS1 — Location
+    expect(segments[6]).toBe('MS1*CHICAGO*IL*US');
+
+    // AT8 — Weight
+    expect(segments[7]).toBe('AT8*G*L*15000*10');
+
+    // SE — Segment count (ST through AT8 = 6, plus SE itself)
+    expect(segments[8]).toMatch(/^SE\*7\*0001$/);
+
+    // GE
+    expect(segments[9]).toMatch(/^GE\*1\*/);
+
+    // IEA
+    expect(segments[10]).toMatch(/^IEA\*1\*/);
+  });
+
+  it('should use QM functional identifier in GS segment', () => {
+    const ediContent = service.generateEDI214({
+      shipmentReference: 'TEST-1',
+      carrierScac: 'WXYZ',
+      statusCode: 'D1',
+      city: 'NEW YORK',
+      state: 'NY',
+      statusDate: new Date(),
+    });
+
+    expect(ediContent).toContain('GS*QM*');
+  });
+
+  it('should generate valid segment count in SE', () => {
+    // Without optional AT8 segment
+    const ediContent = service.generateEDI214({
+      shipmentReference: 'TEST-2',
+      carrierScac: 'ABCD',
+      statusCode: 'X1',
+      city: 'DALLAS',
+      state: 'TX',
+      statusDate: new Date(),
+    });
+
+    const segments = ediContent.split('\n').map(s => s.replace(/~$/, ''));
+    const seSegment = segments.find(s => s.startsWith('SE*'));
+    expect(seSegment).toBeDefined();
+
+    // Count segments from ST to AT8 (no AT8 here) + SE = ST, B10, L11, AT7, MS1, SE = 6
+    expect(seSegment).toMatch(/^SE\*6\*0001$/);
+  });
+
+  it('should omit AT8 when no weight provided', () => {
+    const ediContent = service.generateEDI214({
+      shipmentReference: 'TEST-3',
+      carrierScac: 'ABCD',
+      statusCode: 'OA',
+      city: 'HOUSTON',
+      state: 'TX',
+      statusDate: new Date(),
+    });
+
+    expect(ediContent).not.toContain('AT8*');
+  });
+
+  it('should include additional reference numbers in L11 segments', () => {
+    const ediContent = service.generateEDI214({
+      shipmentReference: 'TEST-4',
+      carrierScac: 'ABCD',
+      statusCode: 'AF',
+      city: 'PHOENIX',
+      state: 'AZ',
+      statusDate: new Date(),
+      referenceNumbers: [
+        { qualifier: 'BM', number: 'BOL-001' },
+        { qualifier: 'PO', number: 'PO-999' },
+      ],
+    });
+
+    expect(ediContent).toContain('L11*TEST-4*SI');
+    expect(ediContent).toContain('L11*BOL-001*BM');
+    expect(ediContent).toContain('L11*PO-999*PO');
+  });
+
+  it('should sanitize special characters from reference fields', () => {
+    const ediContent = service.generateEDI214({
+      shipmentReference: 'SHP*001~test',
+      carrierScac: 'ABCD',
+      statusCode: 'AF',
+      city: 'City*With~Chars',
+      state: 'CA',
+      statusDate: new Date(),
+    });
+
+    // Should not have raw * or ~ inside segment values
+    const b10 = ediContent.split('\n').find(s => s.startsWith('B10'));
+    expect(b10).not.toContain('SHP*001');
+    expect(b10).toContain('SHP 001 test');
+  });
+
+  it('should default country to US when not specified', () => {
+    const ediContent = service.generateEDI214({
+      shipmentReference: 'TEST-5',
+      carrierScac: 'ABCD',
+      statusCode: 'D1',
+      city: 'SEATTLE',
+      state: 'WA',
+      statusDate: new Date(),
+    });
+
+    expect(ediContent).toContain('MS1*SEATTLE*WA*US');
+  });
+
+  it('should handle proNumber fallback to shipmentReference', () => {
+    const ediContent = service.generateEDI214({
+      shipmentReference: 'TEST-6',
+      carrierScac: 'ABCD',
+      statusCode: 'AF',
+      city: 'DENVER',
+      state: 'CO',
+      statusDate: new Date(),
+    });
+
+    // B10 should use shipmentReference as pro number fallback
+    expect(ediContent).toContain('B10*TEST-6*ABCD*TEST-6');
+  });
+});

--- a/backend/src/__tests__/edi214StatusMapping.test.ts
+++ b/backend/src/__tests__/edi214StatusMapping.test.ts
@@ -1,0 +1,104 @@
+import { mapEdi214Status, getDefaultStatusMapping, EDI214_STATUS_MAP } from '../services/edi214StatusMapping.js';
+
+describe('edi214StatusMapping', () => {
+  describe('mapEdi214Status', () => {
+    it('should map AF (picked up) to in_transit', () => {
+      const result = mapEdi214Status('AF');
+      expect(result).not.toBeNull();
+      expect(result!.shipmentStatus).toBe('in_transit');
+      expect(result!.isException).toBe(false);
+    });
+
+    it('should map D1 (delivered) to delivered with complete stop action', () => {
+      const result = mapEdi214Status('D1');
+      expect(result).not.toBeNull();
+      expect(result!.shipmentStatus).toBe('delivered');
+      expect(result!.stopAction).toBe('complete');
+      expect(result!.stopStatus).toBe('completed');
+      expect(result!.isException).toBe(false);
+    });
+
+    it('should map X1 (arrived at facility) with arrive stop action', () => {
+      const result = mapEdi214Status('X1');
+      expect(result).not.toBeNull();
+      expect(result!.shipmentStatus).toBe('in_transit');
+      expect(result!.stopAction).toBe('arrive');
+      expect(result!.stopStatus).toBe('arrived');
+    });
+
+    it('should map X3 (arrived at destination) with arrive stop action', () => {
+      const result = mapEdi214Status('X3');
+      expect(result).not.toBeNull();
+      expect(result!.stopAction).toBe('arrive');
+    });
+
+    it('should map X2 (departed facility) with depart stop action', () => {
+      const result = mapEdi214Status('X2');
+      expect(result).not.toBeNull();
+      expect(result!.stopAction).toBe('depart');
+      expect(result!.stopStatus).toBe('completed');
+    });
+
+    it('should map A7 (refused) as exception', () => {
+      const result = mapEdi214Status('A7');
+      expect(result).not.toBeNull();
+      expect(result!.shipmentStatus).toBe('exception');
+      expect(result!.isException).toBe(true);
+      expect(result!.exceptionType).toBe('refused');
+    });
+
+    it('should map A9 (damaged) as exception', () => {
+      const result = mapEdi214Status('A9');
+      expect(result).not.toBeNull();
+      expect(result!.isException).toBe(true);
+      expect(result!.exceptionType).toBe('damage');
+    });
+
+    it('should map AH (attempted delivery) as exception', () => {
+      const result = mapEdi214Status('AH');
+      expect(result).not.toBeNull();
+      expect(result!.isException).toBe(true);
+      expect(result!.exceptionType).toBe('delay');
+    });
+
+    it('should map AM (carrier delay) as exception', () => {
+      const result = mapEdi214Status('AM');
+      expect(result).not.toBeNull();
+      expect(result!.isException).toBe(true);
+      expect(result!.exceptionType).toBe('delay');
+    });
+
+    it('should return null for unknown status codes', () => {
+      expect(mapEdi214Status('ZZ')).toBeNull();
+      expect(mapEdi214Status('XX')).toBeNull();
+      expect(mapEdi214Status('')).toBeNull();
+    });
+
+    it('should be case insensitive', () => {
+      expect(mapEdi214Status('af')).not.toBeNull();
+      expect(mapEdi214Status('d1')).not.toBeNull();
+      expect(mapEdi214Status('a7')).not.toBeNull();
+    });
+
+    it('should have eventDescription for every mapped code', () => {
+      for (const [code, mapping] of Object.entries(EDI214_STATUS_MAP)) {
+        expect(mapping.eventDescription).toBeTruthy();
+        expect(mapping.eventDescription.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('getDefaultStatusMapping', () => {
+    it('should return in_transit status for unknown codes', () => {
+      const result = getDefaultStatusMapping('ZZ');
+      expect(result.shipmentStatus).toBe('in_transit');
+      expect(result.isException).toBe(false);
+      expect(result.stopAction).toBeNull();
+    });
+
+    it('should include the status code in the description', () => {
+      const result = getDefaultStatusMapping('XX');
+      expect(result.eventDescription).toContain('XX');
+    });
+  });
+});

--- a/backend/src/commands/shipments/ProcessInbound214Command.ts
+++ b/backend/src/commands/shipments/ProcessInbound214Command.ts
@@ -1,0 +1,269 @@
+import { PrismaClient } from '@prisma/client';
+import { PgBossEventBus } from '../../events/PgBossEventBus.js';
+import { EVENT_TYPES } from '../../events/eventTypes.js';
+import { BaseCommandHandler, TransactionClient, EmitFn } from '../BaseCommandHandler.js';
+import { Command } from '../types.js';
+import { mapEdi214Status, getDefaultStatusMapping } from '../../services/edi214StatusMapping.js';
+
+export interface ProcessInbound214Payload {
+  shipmentId: string;
+  carrierScac: string;
+  proNumber: string;
+  statusCode: string;
+  reasonCode?: string;
+  city: string;
+  state: string;
+  country?: string;
+  statusDate: string; // ISO-8601
+  weight?: number;
+  referenceNumbers?: Array<{ qualifier: string; number: string }>;
+  rawEdiContent: string;
+  tradingPartnerId?: string;
+}
+
+export const PROCESS_INBOUND_214 = 'shipment.process_inbound_214';
+
+export class ProcessInbound214CommandHandler extends BaseCommandHandler<
+  ProcessInbound214Payload,
+  { id: string; statusApplied: string }
+> {
+  readonly commandType = PROCESS_INBOUND_214;
+
+  constructor(prisma: PrismaClient, eventBus: PgBossEventBus) {
+    super(prisma, eventBus);
+  }
+
+  protected async handle(
+    command: Command<ProcessInbound214Payload>,
+    tx: TransactionClient,
+    emit: EmitFn
+  ): Promise<{ id: string; statusApplied: string }> {
+    const {
+      shipmentId, carrierScac, proNumber, statusCode,
+      reasonCode, city, state, country, statusDate,
+      rawEdiContent, tradingPartnerId,
+    } = command.payload;
+
+    // 1. Find shipment, ensure it exists and is not archived
+    const shipment = await tx.shipment.findFirstOrThrow({
+      where: { id: shipmentId, archived: false },
+      include: {
+        stops: {
+          include: { location: true },
+          orderBy: { sequenceNumber: 'asc' },
+        },
+      },
+    });
+
+    // 2. Resolve status mapping
+    const mapping = mapEdi214Status(statusCode) || getDefaultStatusMapping(statusCode);
+
+    // 3. Update shipment status if it differs
+    const updateData: Record<string, unknown> = {};
+    const statusChanged = mapping.shipmentStatus !== shipment.status;
+
+    if (statusChanged) {
+      updateData.status = mapping.shipmentStatus;
+    }
+
+    // Set proNumber if we received one and don't already have it
+    if (proNumber && !shipment.proNumber) {
+      updateData.proNumber = proNumber;
+    }
+
+    if (Object.keys(updateData).length > 0) {
+      await tx.shipment.update({ where: { id: shipmentId }, data: updateData });
+    }
+
+    // 4. Update matching ShipmentStop if the mapping calls for it
+    let matchedStopId: string | null = null;
+    if (mapping.stopAction && city && shipment.stops.length > 0) {
+      const matchedStop = this.findMatchingStop(
+        shipment.stops,
+        city,
+        state,
+        mapping.stopAction,
+      );
+
+      if (matchedStop) {
+        matchedStopId = matchedStop.id;
+        const stopUpdate: Record<string, unknown> = {};
+        const eventTime = new Date(statusDate);
+
+        if (mapping.stopStatus) {
+          stopUpdate.status = mapping.stopStatus;
+        }
+
+        if (mapping.stopAction === 'arrive') {
+          stopUpdate.actualArrival = eventTime;
+          stopUpdate.status = 'arrived';
+        } else if (mapping.stopAction === 'depart' || mapping.stopAction === 'complete') {
+          stopUpdate.actualDeparture = eventTime;
+          stopUpdate.status = 'completed';
+        }
+
+        await tx.shipmentStop.update({ where: { id: matchedStop.id }, data: stopUpdate });
+      }
+    }
+
+    // 5. Create ShipmentEvent for audit trail
+    await tx.shipmentEvent.create({
+      data: {
+        shipmentId,
+        eventType: 'edi_214',
+        address: city && state ? `${city}, ${state}` : city || '',
+        rawPayload: {
+          statusCode,
+          reasonCode: reasonCode || null,
+          carrierScac,
+          proNumber,
+          tradingPartnerId: tradingPartnerId || null,
+          statusDescription: mapping.eventDescription,
+        },
+        eventTime: new Date(statusDate),
+      },
+    });
+
+    // 6. Emit domain events
+
+    // Always emit EDI_214_RECEIVED
+    emit(this.createEvent(command, {
+      type: EVENT_TYPES.EDI_214_RECEIVED,
+      entityType: 'shipment',
+      entityId: shipmentId,
+      payload: {
+        shipmentId,
+        shipmentReference: shipment.reference,
+        carrierScac,
+        proNumber,
+        statusCode,
+        statusDescription: mapping.eventDescription,
+        city,
+        state,
+        tradingPartnerId,
+      },
+    }));
+
+    // Emit SHIPMENT_STATUS_CHANGED if status actually changed
+    if (statusChanged) {
+      emit(this.createEvent(command, {
+        type: EVENT_TYPES.SHIPMENT_STATUS_CHANGED,
+        entityType: 'shipment',
+        entityId: shipmentId,
+        payload: {
+          previousStatus: shipment.status,
+          newStatus: mapping.shipmentStatus,
+          shipmentReference: shipment.reference,
+        },
+      }));
+    }
+
+    // Emit stop-level events
+    if (matchedStopId && mapping.stopAction === 'arrive') {
+      emit(this.createEvent(command, {
+        type: EVENT_TYPES.SHIPMENT_STOP_ARRIVED,
+        entityType: 'shipment',
+        entityId: shipmentId,
+        payload: {
+          stopId: matchedStopId,
+          shipmentReference: shipment.reference,
+          location: city && state ? `${city}, ${state}` : city,
+        },
+      }));
+    }
+
+    if (matchedStopId && (mapping.stopAction === 'complete' || mapping.stopAction === 'depart')) {
+      emit(this.createEvent(command, {
+        type: EVENT_TYPES.SHIPMENT_STOP_COMPLETED,
+        entityType: 'shipment',
+        entityId: shipmentId,
+        payload: {
+          stopId: matchedStopId,
+          shipmentReference: shipment.reference,
+          location: city && state ? `${city}, ${state}` : city,
+        },
+      }));
+    }
+
+    // Emit exception event if applicable
+    if (mapping.isException) {
+      emit(this.createEvent(command, {
+        type: EVENT_TYPES.SHIPMENT_EXCEPTION,
+        entityType: 'shipment',
+        entityId: shipmentId,
+        payload: {
+          shipmentReference: shipment.reference,
+          exceptionType: mapping.exceptionType || 'edi_214',
+          description: mapping.eventDescription,
+        },
+      }));
+    }
+
+    // Emit delivered event for D1
+    if (mapping.shipmentStatus === 'delivered' && statusChanged) {
+      emit(this.createEvent(command, {
+        type: EVENT_TYPES.SHIPMENT_DELIVERED,
+        entityType: 'shipment',
+        entityId: shipmentId,
+        payload: {
+          shipmentReference: shipment.reference,
+          deliveredAt: statusDate,
+        },
+      }));
+    }
+
+    return { id: shipmentId, statusApplied: mapping.shipmentStatus };
+  }
+
+  /**
+   * Find the best matching ShipmentStop by city/state.
+   *
+   * Strategy:
+   * - For arrivals: find first pending/in_progress stop where location matches
+   * - For departures: find first arrived stop where location matches
+   * - For completions: find last stop (destination) or location match
+   * - Fall back to sequential: first pending stop for arrive, first arrived for depart
+   */
+  private findMatchingStop(
+    stops: Array<{ id: string; status: string; sequenceNumber: number; location: { city: string; state: string | null } }>,
+    city: string,
+    state: string,
+    action: 'arrive' | 'depart' | 'complete',
+  ): { id: string } | null {
+    const cityLower = city.toLowerCase();
+    const stateLower = state.toLowerCase();
+
+    // Try to match by city+state
+    const locationMatch = stops.filter(s =>
+      s.location.city.toLowerCase() === cityLower &&
+      (s.location.state || '').toLowerCase() === stateLower
+    );
+
+    if (action === 'arrive') {
+      // Prefer a pending stop at this location
+      const pendingAtLoc = locationMatch.find(s => s.status === 'pending');
+      if (pendingAtLoc) return pendingAtLoc;
+      // Fall back: first pending stop overall
+      return stops.find(s => s.status === 'pending') || null;
+    }
+
+    if (action === 'depart') {
+      // Prefer an arrived stop at this location
+      const arrivedAtLoc = locationMatch.find(s => s.status === 'arrived');
+      if (arrivedAtLoc) return arrivedAtLoc;
+      // Fall back: first arrived stop overall
+      return stops.find(s => s.status === 'arrived') || null;
+    }
+
+    if (action === 'complete') {
+      // Prefer a non-completed stop at this location
+      const activeAtLoc = locationMatch.find(s => s.status !== 'completed' && s.status !== 'skipped');
+      if (activeAtLoc) return activeAtLoc;
+      // Fall back: last non-completed stop (likely destination)
+      const active = stops.filter(s => s.status !== 'completed' && s.status !== 'skipped');
+      return active.length > 0 ? active[active.length - 1] : null;
+    }
+
+    return null;
+  }
+}

--- a/backend/src/di/registry.ts
+++ b/backend/src/di/registry.ts
@@ -89,6 +89,9 @@ import { TradingPartnerRepository } from '../repositories/TradingPartnerReposito
 import { EdiRouterService } from '../services/EdiRouterService.js';
 import { OutboundEdiDeliveryService } from '../services/OutboundEdiDeliveryService.js';
 import { EDI997Service } from '../services/EDI997Service.js';
+import { EDI214ParseService } from '../services/EDI214ParseService.js';
+import { EDI214Service } from '../services/EDI214Service.js';
+import { ProcessInbound214CommandHandler } from '../commands/shipments/ProcessInbound214Command.js';
 
 /**
  * Register all application dependencies
@@ -336,6 +339,14 @@ export function registerDependencies(prisma: PrismaClient): void {
     return new EDI997Service();
   });
 
+  container.singleton(TOKENS.IEDI214ParseService).toFactory(() => {
+    return new EDI214ParseService();
+  });
+
+  container.singleton(TOKENS.IEDI214Service).toFactory(() => {
+    return new EDI214Service();
+  });
+
   // EDI services
   container.singleton(TOKENS.IEDI850ParseService).toFactory(() => {
     return new EDI850ParseService();
@@ -425,6 +436,9 @@ export function registerDependencies(prisma: PrismaClient): void {
     // CAPA commands
     bus.register(new CreateCAPACommandHandler(prisma, eventBus));
     bus.register(new UpdateCAPACommandHandler(prisma, eventBus));
+
+    // EDI 214 commands
+    bus.register(new ProcessInbound214CommandHandler(prisma, eventBus));
 
     return bus;
   });

--- a/backend/src/di/tokens.ts
+++ b/backend/src/di/tokens.ts
@@ -64,6 +64,8 @@ export const TOKENS = {
   IEdiRouterService: Symbol.for('IEdiRouterService'),
   IOutboundEdiDeliveryService: Symbol.for('IOutboundEdiDeliveryService'),
   IEDI997Service: Symbol.for('IEDI997Service'),
+  IEDI214ParseService: Symbol.for('IEDI214ParseService'),
+  IEDI214Service: Symbol.for('IEDI214Service'),
 
   // Infrastructure tokens
   PrismaClient: Symbol.for('PrismaClient'),

--- a/backend/src/events/eventTypes.ts
+++ b/backend/src/events/eventTypes.ts
@@ -120,6 +120,10 @@ export const EVENT_TYPES = {
   INTEGRATION_OUTBOUND_SENT: 'integration.outbound_sent',
   INTEGRATION_OUTBOUND_FAILED: 'integration.outbound_failed',
   INTEGRATION_WEBHOOK_RECEIVED: 'integration.webhook_received',
+
+  // EDI 214 (Shipment Status)
+  EDI_214_RECEIVED: 'edi_status.received',
+  EDI_214_SENT: 'edi_status.sent',
 } as const;
 
 export type EventType = typeof EVENT_TYPES[keyof typeof EVENT_TYPES];
@@ -183,6 +187,8 @@ export const EVENT_SCHEMA_VERSIONS: Record<string, number> = {
   [EVENT_TYPES.CAPA_STATUS_CHANGED]: 1,
   [EVENT_TYPES.CAPA_APPROVED]: 1,
   [EVENT_TYPES.CAPA_VERIFIED]: 1,
+  [EVENT_TYPES.EDI_214_RECEIVED]: 1,
+  [EVENT_TYPES.EDI_214_SENT]: 1,
 };
 
 /**
@@ -341,4 +347,24 @@ export interface CAPAStatusChangedPayload {
   title: string;
   previousStatus: string;
   newStatus: string;
+}
+
+// EDI 214 payloads
+export interface Edi214ReceivedPayload {
+  shipmentId: string;
+  shipmentReference: string;
+  carrierScac: string;
+  proNumber: string;
+  statusCode: string;
+  statusDescription: string;
+  city: string;
+  state: string;
+  tradingPartnerId?: string;
+}
+
+export interface Edi214SentPayload {
+  shipmentId: string;
+  shipmentReference: string;
+  tradingPartnerId: string;
+  statusCode: string;
 }

--- a/backend/src/events/handlers/Edi214ForwardHandler.ts
+++ b/backend/src/events/handlers/Edi214ForwardHandler.ts
@@ -1,0 +1,98 @@
+/**
+ * Edi214ForwardHandler
+ *
+ * Listens for edi_214.received events (inbound carrier status updates).
+ * When a carrier sends a 214, this handler auto-forwards an outbound 214
+ * to any customer trading partner that has outbound 214 enabled.
+ *
+ * This gives customers automatic visibility into their shipment status
+ * without requiring manual intervention.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { DomainEvent } from '../DomainEvent.js';
+import { IEventHandler } from '../IEventHandler.js';
+import { EVENT_TYPES, Edi214ReceivedPayload } from '../eventTypes.js';
+import { EDI214Service, EDI214ShipmentData } from '../../services/EDI214Service.js';
+import { OutboundEdiDeliveryService } from '../../services/OutboundEdiDeliveryService.js';
+
+export class Edi214ForwardHandler implements IEventHandler {
+  readonly name = 'handler.edi214_forward';
+  readonly eventPatterns = [EVENT_TYPES.EDI_214_RECEIVED];
+  readonly options = { concurrency: 2 };
+
+  constructor(
+    private prisma: PrismaClient,
+    private edi214Service: EDI214Service,
+    private deliveryService: OutboundEdiDeliveryService,
+  ) {}
+
+  async handle(event: DomainEvent): Promise<void> {
+    try {
+      if (event.type !== EVENT_TYPES.EDI_214_RECEIVED) return;
+
+      const payload = event.payload as Edi214ReceivedPayload;
+      const { shipmentId, shipmentReference, carrierScac, statusCode, city, state } = payload;
+
+      // Load shipment to get customer ID
+      const shipment = await this.prisma.shipment.findUnique({
+        where: { id: shipmentId },
+        select: { customerId: true, proNumber: true },
+      });
+
+      if (!shipment?.customerId) return;
+
+      // Find customer trading partners with outbound 214 enabled
+      const partners = await this.prisma.tradingPartner.findMany({
+        where: {
+          active: true,
+          outboundEnabled: true,
+          customerId: shipment.customerId,
+          transactions: {
+            some: {
+              transactionType: '214',
+              direction: 'outbound',
+              enabled: true,
+            },
+          },
+        },
+      });
+
+      if (partners.length === 0) return;
+
+      // Generate 214 for each customer partner
+      for (const partner of partners) {
+        try {
+          const ediData: EDI214ShipmentData = {
+            shipmentReference,
+            proNumber: shipment.proNumber || undefined,
+            carrierScac,
+            statusCode,
+            city: city || '',
+            state: state || '',
+            statusDate: new Date(),
+          };
+
+          const ediContent = this.edi214Service.generateEDI214(ediData, {
+            senderId: partner.senderId || 'OPENTMS',
+            receiverId: partner.receiverId || undefined,
+          });
+
+          await this.deliveryService.deliver({
+            partnerId: partner.id,
+            transactionType: '214',
+            ediContent,
+            referenceId: shipmentReference,
+            shipmentId,
+          });
+
+          console.log(`[Edi214ForwardHandler] Forwarded 214 (${statusCode}) for ${shipmentReference} to partner ${partner.name}`);
+        } catch (err) {
+          console.error(`[Edi214ForwardHandler] Failed to forward 214 to partner ${partner.name}:`, (err as Error).message);
+        }
+      }
+    } catch (err) {
+      console.error(`[Edi214ForwardHandler] Error processing ${event.type}:`, err);
+    }
+  }
+}

--- a/backend/src/events/registerHandlers.ts
+++ b/backend/src/events/registerHandlers.ts
@@ -17,6 +17,10 @@ import { CustomerProjection } from './projections/CustomerProjection.js';
 import { LaneProjection } from './projections/LaneProjection.js';
 import { IssueProjection } from './projections/IssueProjection.js';
 import { ColdChainComplianceHandler } from './handlers/ColdChainComplianceHandler.js';
+import { Edi214ForwardHandler } from './handlers/Edi214ForwardHandler.js';
+import { EDI214Service } from '../services/EDI214Service.js';
+import { OutboundEdiDeliveryService } from '../services/OutboundEdiDeliveryService.js';
+import { TradingPartnerRepository } from '../repositories/TradingPartnerRepository.js';
 import { IBinaryStorageProvider } from '../storage/IBinaryStorageProvider.js';
 
 /** Read concurrency from env with a default */
@@ -68,6 +72,12 @@ export async function registerEventHandlers(
   if (storageProvider) {
     handlers.push(new ColdChainComplianceHandler(prisma, storageProvider));
   }
+
+  // Add EDI 214 auto-forward handler
+  const tradingPartnerRepo = new TradingPartnerRepository(prisma);
+  const edi214GenerationService = new EDI214Service();
+  const outboundDeliveryService = new OutboundEdiDeliveryService(tradingPartnerRepo);
+  handlers.push(new Edi214ForwardHandler(prisma, edi214GenerationService, outboundDeliveryService));
 
   for (const handler of handlers) {
     // Apply env-based concurrency overrides

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -50,6 +50,7 @@ import { tenderRoutes } from './routes/tenders.js';
 import { carrierPortalRoutes } from './routes/carrierPortal.js';
 import { carrierUserRoutes } from './routes/carrierUsers.js';
 import { ediTenderRoutes } from './routes/ediTender.js';
+import { edi214Routes } from './routes/edi214.js';
 import { tradingPartnerRoutes } from './routes/tradingPartners.js';
 import deviceRoutes from './routes/devices.js';
 import telemetryRoutes from './routes/telemetry.js';
@@ -122,6 +123,7 @@ async function start() {
   await server.register(carrierPortalRoutes);
   await server.register(carrierUserRoutes);
   await server.register(ediTenderRoutes);
+  await server.register(edi214Routes);
   await server.register(tradingPartnerRoutes);
   await server.register(deviceRoutes);
   await server.register(telemetryRoutes);

--- a/backend/src/routes/edi214.ts
+++ b/backend/src/routes/edi214.ts
@@ -1,0 +1,351 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { container, TOKENS } from '../di/index.js';
+import { EDI214ParseService } from '../services/EDI214ParseService.js';
+import { EDI214Service, EDI214ShipmentData } from '../services/EDI214Service.js';
+import { EDI997Service } from '../services/EDI997Service.js';
+import { IOutboundEdiDeliveryService } from '../services/OutboundEdiDeliveryService.js';
+import { ITradingPartnerRepository } from '../repositories/TradingPartnerRepository.js';
+import { PROCESS_INBOUND_214 } from '../commands/shipments/ProcessInbound214Command.js';
+import { mapEdi214Status, getDefaultStatusMapping } from '../services/edi214StatusMapping.js';
+import { CommandBus } from '../commands/CommandBus.js';
+import crypto from 'crypto';
+
+export async function edi214Routes(server: FastifyInstance) {
+  const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
+  const commandBus = container.resolve<CommandBus>(TOKENS.ICommandBus);
+  const edi214Parser = new EDI214ParseService();
+  const edi214Service = new EDI214Service();
+  const edi997Service = container.resolve<EDI997Service>(TOKENS.IEDI997Service);
+  const deliveryService = container.resolve<IOutboundEdiDeliveryService>(TOKENS.IOutboundEdiDeliveryService);
+  const tradingPartnerRepo = container.resolve<ITradingPartnerRepository>(TOKENS.ITradingPartnerRepository);
+
+  /**
+   * POST /api/v1/edi/214/inbound — Receive inbound EDI 214 from carrier
+   */
+  server.post('/api/v1/edi/214/inbound', {
+    schema: {
+      tags: ['EDI 214'],
+      summary: 'Receive inbound EDI 214 (Shipment Status Message)',
+      body: {
+        type: 'object',
+        required: ['content'],
+        properties: {
+          content: { type: 'string' },
+          partnerId: { type: 'string' },
+          fileName: { type: 'string' },
+        },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { content, partnerId, fileName } = z.object({
+      content: z.string().min(1),
+      partnerId: z.string().optional(),
+      fileName: z.string().optional(),
+    }).parse((req as any).body);
+
+    // 1. Parse EDI 214
+    const parseResult = edi214Parser.parseEDI214(content);
+
+    if (!parseResult.success) {
+      reply.code(400);
+      return { data: null, error: `EDI 214 parse failed: ${parseResult.errors.join('; ')}` };
+    }
+
+    // 2. Find matching shipment by reference or pro number
+    const shipment = await prisma.shipment.findFirst({
+      where: {
+        archived: false,
+        OR: [
+          { reference: parseResult.shipmentReference },
+          { proNumber: parseResult.proNumber },
+          ...(parseResult.shipmentReference ? [{ proNumber: parseResult.shipmentReference }] : []),
+          ...(parseResult.proNumber ? [{ reference: parseResult.proNumber }] : []),
+        ],
+      },
+      include: { carrier: true },
+    });
+
+    if (!shipment) {
+      reply.code(404);
+      return {
+        data: null,
+        error: `No matching shipment found for reference "${parseResult.shipmentReference}" / pro "${parseResult.proNumber}"`,
+      };
+    }
+
+    // Use the most recent status detail (last AT7 in the document)
+    const latestStatus = parseResult.statusDetails[parseResult.statusDetails.length - 1];
+
+    // 3. Dispatch command to update shipment
+    const result = await commandBus.dispatch({
+      type: PROCESS_INBOUND_214,
+      orgId: shipment.orgId,
+      actorId: null,
+      payload: {
+        shipmentId: shipment.id,
+        carrierScac: parseResult.carrierScac,
+        proNumber: parseResult.proNumber,
+        statusCode: latestStatus.statusCode,
+        reasonCode: latestStatus.reasonCode || undefined,
+        city: latestStatus.city,
+        state: latestStatus.state,
+        country: latestStatus.country || undefined,
+        statusDate: latestStatus.date
+          ? formatEdiDate(latestStatus.date, latestStatus.time)
+          : new Date().toISOString(),
+        rawEdiContent: content,
+        tradingPartnerId: partnerId,
+      },
+      metadata: {
+        correlationId: crypto.randomUUID(),
+        source: 'edi_214',
+        idempotencyKey: computeFileHash(content),
+      },
+    });
+
+    if (!result.success) {
+      reply.code(500);
+      return { data: null, error: result.error };
+    }
+
+    // 4. Log to EdiTransactionLog
+    await prisma.ediTransactionLog.create({
+      data: {
+        partnerId: partnerId || undefined,
+        transactionType: '214',
+        direction: 'inbound',
+        fileName: fileName || undefined,
+        fileSize: content.length,
+        fileContent: content,
+        fileHash: computeFileHash(content),
+        transport: 'http',
+        status: 'success',
+        processedAt: new Date(),
+        shipmentId: shipment.id,
+        shipmentReference: shipment.reference,
+      },
+    });
+
+    // 5. Generate 997 acknowledgment if required
+    let ack997Sent = false;
+    if (partnerId) {
+      const partner = await tradingPartnerRepo.findById(partnerId);
+      if (partner) {
+        const txn214 = (partner as any).transactions?.find(
+          (t: any) => t.transactionType === '214' && t.direction === 'inbound'
+        );
+        if (txn214?.ack997Required) {
+          try {
+            const ack997Content = edi997Service.generate997({
+              senderId: partner.senderId || 'OPENTMS',
+              receiverId: partner.receiverId || parseResult.carrierScac,
+              originalTransactionType: '214',
+              originalControlNumber: '0001',
+              accepted: true,
+            });
+
+            await deliveryService.deliver({
+              partnerId,
+              transactionType: '997',
+              ediContent: ack997Content,
+              referenceId: shipment.reference,
+              shipmentId: shipment.id,
+            });
+            ack997Sent = true;
+          } catch (err) {
+            console.error('[EDI 214] Failed to send 997 acknowledgment:', (err as Error).message);
+          }
+        }
+      }
+    }
+
+    const mapping = mapEdi214Status(latestStatus.statusCode) || getDefaultStatusMapping(latestStatus.statusCode);
+
+    return {
+      data: {
+        action: mapping.eventDescription,
+        shipmentId: shipment.id,
+        shipmentReference: shipment.reference,
+        statusCode: latestStatus.statusCode,
+        statusApplied: mapping.shipmentStatus,
+        ack997Sent,
+      },
+      error: null,
+    };
+  });
+
+  /**
+   * POST /api/v1/edi/214/generate — Generate and deliver outbound EDI 214
+   */
+  server.post('/api/v1/edi/214/generate', {
+    schema: {
+      tags: ['EDI 214'],
+      summary: 'Generate and deliver outbound EDI 214 (Shipment Status) to trading partner',
+      body: {
+        type: 'object',
+        required: ['shipmentId', 'statusCode'],
+        properties: {
+          shipmentId: { type: 'string' },
+          statusCode: { type: 'string' },
+          partnerId: { type: 'string' },
+        },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { shipmentId, statusCode, partnerId } = z.object({
+      shipmentId: z.string().min(1),
+      statusCode: z.string().min(1),
+      partnerId: z.string().optional(),
+    }).parse((req as any).body);
+
+    const shipment = await prisma.shipment.findUnique({
+      where: { id: shipmentId },
+      include: {
+        origin: true,
+        destination: true,
+        carrier: true,
+      },
+    });
+
+    if (!shipment) {
+      reply.code(404);
+      return { data: null, error: 'Shipment not found' };
+    }
+
+    const ediData: EDI214ShipmentData = {
+      shipmentReference: shipment.reference,
+      proNumber: shipment.proNumber || undefined,
+      carrierScac: shipment.carrier?.scacCode || 'UNKN',
+      statusCode,
+      city: shipment.destination?.city || '',
+      state: shipment.destination?.state || '',
+      country: shipment.destination?.country || 'US',
+      statusDate: new Date(),
+    };
+
+    // Find partner to deliver to
+    let targetPartnerId = partnerId;
+    if (!targetPartnerId) {
+      // Auto-detect: find customer trading partner with outbound 214
+      const partners = await prisma.tradingPartner.findMany({
+        where: {
+          active: true,
+          outboundEnabled: true,
+          customerId: shipment.customerId,
+          transactions: { some: { transactionType: '214', direction: 'outbound', enabled: true } },
+        },
+        include: { transactions: true },
+      });
+      if (partners.length > 0) {
+        targetPartnerId = partners[0].id;
+      }
+    }
+
+    const partner = targetPartnerId ? await tradingPartnerRepo.findById(targetPartnerId) : null;
+
+    const ediContent = edi214Service.generateEDI214(ediData, {
+      senderId: partner?.senderId || 'OPENTMS',
+      receiverId: partner?.receiverId || ediData.carrierScac,
+    });
+
+    let delivered = false;
+    let logId: string | undefined;
+
+    if (targetPartnerId) {
+      try {
+        const deliveryResult = await deliveryService.deliver({
+          partnerId: targetPartnerId,
+          transactionType: '214',
+          ediContent,
+          referenceId: shipment.reference,
+          shipmentId,
+        });
+        delivered = deliveryResult?.success ?? false;
+        logId = deliveryResult?.logId;
+      } catch (err) {
+        console.error('[EDI 214] Delivery failed:', (err as Error).message);
+      }
+    }
+
+    return {
+      data: {
+        ediContent,
+        delivered,
+        logId,
+        partnerId: targetPartnerId || null,
+      },
+      error: null,
+    };
+  });
+
+  /**
+   * POST /api/v1/edi/214/preview — Preview outbound EDI 214 without delivering
+   */
+  server.post('/api/v1/edi/214/preview', {
+    schema: {
+      tags: ['EDI 214'],
+      summary: 'Preview outbound EDI 214 content without delivering',
+      body: {
+        type: 'object',
+        required: ['shipmentId', 'statusCode'],
+        properties: {
+          shipmentId: { type: 'string' },
+          statusCode: { type: 'string' },
+        },
+      },
+    },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { shipmentId, statusCode } = z.object({
+      shipmentId: z.string().min(1),
+      statusCode: z.string().min(1),
+    }).parse((req as any).body);
+
+    const shipment = await prisma.shipment.findUnique({
+      where: { id: shipmentId },
+      include: {
+        origin: true,
+        destination: true,
+        carrier: true,
+      },
+    });
+
+    if (!shipment) {
+      reply.code(404);
+      return { data: null, error: 'Shipment not found' };
+    }
+
+    const ediContent = edi214Service.generateEDI214({
+      shipmentReference: shipment.reference,
+      proNumber: shipment.proNumber || undefined,
+      carrierScac: shipment.carrier?.scacCode || 'UNKN',
+      statusCode,
+      city: shipment.destination?.city || '',
+      state: shipment.destination?.state || '',
+      country: shipment.destination?.country || 'US',
+      statusDate: new Date(),
+    });
+
+    return {
+      data: { ediContent, shipmentReference: shipment.reference },
+      error: null,
+    };
+  });
+}
+
+/** Convert EDI date (CCYYMMDD) + time (HHMM) to ISO-8601 */
+function formatEdiDate(date: string, time?: string): string {
+  if (date.length !== 8) return new Date().toISOString();
+  const y = date.substring(0, 4);
+  const m = date.substring(4, 6);
+  const d = date.substring(6, 8);
+  const h = time?.substring(0, 2) || '00';
+  const min = time?.substring(2, 4) || '00';
+  return new Date(`${y}-${m}-${d}T${h}:${min}:00Z`).toISOString();
+}
+
+/** SHA-256 hash for deduplication */
+function computeFileHash(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}

--- a/backend/src/services/EDI214ParseService.ts
+++ b/backend/src/services/EDI214ParseService.ts
@@ -1,0 +1,224 @@
+/**
+ * EDI 214 (Shipment Status Message) Parse Service
+ *
+ * Parses inbound X12 214 documents to extract carrier shipment status updates.
+ * Carriers send 214s to report pickup, in-transit, delivery, and exception statuses.
+ *
+ * Key segments:
+ *   B10 — Shipment identification (reference, carrier SCAC, pro number)
+ *   L11 — Business reference numbers
+ *   AT7 — Shipment status detail (status code, reason, date, time)
+ *   MS1 — Equipment location (city, state, country)
+ *   AT8 — Shipment weight and piece count
+ */
+
+export interface EDI214StatusDetail {
+  /** AT7-01: Status code (AF, X1, D1, A7, etc.) */
+  statusCode: string;
+  /** AT7-02: Reason code */
+  reasonCode: string;
+  /** Location city (from AT7 or MS1) */
+  city: string;
+  /** Location state (from AT7 or MS1) */
+  state: string;
+  /** Location country */
+  country: string;
+  /** Date from AT7 (CCYYMMDD) */
+  date: string;
+  /** Time from AT7 (HHMM) */
+  time: string;
+  /** Time zone code from AT7 */
+  timeZone: string;
+}
+
+export interface EDI214ParseResult {
+  success: boolean;
+  /** B10-01: Reference identification */
+  shipmentReference: string;
+  /** B10-02: Standard Carrier Alpha Code */
+  carrierScac: string;
+  /** B10-03: Pro number / shipment identifier */
+  proNumber: string;
+  /** Status updates (one or more AT7+MS1 pairs) */
+  statusDetails: EDI214StatusDetail[];
+  /** L11 reference numbers */
+  referenceNumbers: Array<{ qualifier: string; number: string }>;
+  /** AT8 weight info */
+  weight?: { weight: number; qualifier: string; ladingQuantity?: number };
+  /** Original raw content for audit */
+  rawContent: string;
+  /** Parse errors */
+  errors: string[];
+}
+
+export interface IEDI214ParseService {
+  parseEDI214(content: string): EDI214ParseResult;
+}
+
+export class EDI214ParseService implements IEDI214ParseService {
+  parseEDI214(content: string): EDI214ParseResult {
+    const errors: string[] = [];
+    const referenceNumbers: Array<{ qualifier: string; number: string }> = [];
+    const statusDetails: EDI214StatusDetail[] = [];
+    let shipmentReference = '';
+    let carrierScac = '';
+    let proNumber = '';
+    let weight: { weight: number; qualifier: string; ladingQuantity?: number } | undefined;
+
+    try {
+      // Normalize content: handle both newline and tilde delimiters
+      const normalized = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+      // Split into segments by tilde terminator
+      const rawSegments = normalized.split('~')
+        .map(s => s.trim().replace(/^\n+/, ''))
+        .filter(s => s.length > 0);
+
+      const separator = '*';
+      let foundST = false;
+      let found214 = false;
+
+      // Track current AT7 to pair with following MS1
+      let pendingStatus: Partial<EDI214StatusDetail> | null = null;
+
+      for (const rawSeg of rawSegments) {
+        const elements = rawSeg.split(separator);
+        const segId = elements[0]?.toUpperCase();
+
+        // ST — Transaction Set Header
+        if (segId === 'ST') {
+          foundST = true;
+          if (elements[1] === '214') {
+            found214 = true;
+          }
+        }
+
+        // B10 — Shipment identification
+        if (segId === 'B10') {
+          shipmentReference = elements[1] || '';
+          carrierScac = elements[2] || '';
+          proNumber = elements[3] || '';
+        }
+
+        // L11 — Reference numbers
+        if (segId === 'L11') {
+          const number = elements[1] || '';
+          const qualifier = elements[2] || '';
+          if (number || qualifier) {
+            referenceNumbers.push({ qualifier, number });
+          }
+        }
+
+        // AT7 — Shipment status detail
+        if (segId === 'AT7') {
+          // Flush any pending status without MS1
+          if (pendingStatus) {
+            statusDetails.push(this.finalizePendingStatus(pendingStatus));
+          }
+
+          pendingStatus = {
+            statusCode: elements[1] || '',
+            reasonCode: elements[2] || '',
+            // AT7 can have date/time in positions 5/6/7
+            date: elements[5] || '',
+            time: elements[6] || '',
+            timeZone: elements[7] || '',
+            city: '',
+            state: '',
+            country: '',
+          };
+        }
+
+        // MS1 — Equipment location (follows AT7)
+        if (segId === 'MS1') {
+          const city = elements[1] || '';
+          const state = elements[2] || '';
+          const country = elements[3] || '';
+
+          if (pendingStatus) {
+            pendingStatus.city = city;
+            pendingStatus.state = state;
+            pendingStatus.country = country;
+            statusDetails.push(this.finalizePendingStatus(pendingStatus));
+            pendingStatus = null;
+          }
+        }
+
+        // AT8 — Shipment weight
+        if (segId === 'AT8') {
+          const weightQualifier = elements[1] || '';
+          const weightValue = parseFloat(elements[3] || '0');
+          const ladingQty = elements[4] ? parseInt(elements[4], 10) : undefined;
+          if (weightValue > 0) {
+            weight = { weight: weightValue, qualifier: weightQualifier, ladingQuantity: ladingQty };
+          }
+        }
+
+        // MS3 — Interline carrier info (fallback for SCAC)
+        if (segId === 'MS3') {
+          if (!carrierScac && elements[1]) {
+            carrierScac = elements[1];
+          }
+        }
+      }
+
+      // Flush any remaining pending status
+      if (pendingStatus) {
+        statusDetails.push(this.finalizePendingStatus(pendingStatus));
+      }
+
+      // Validation
+      if (!found214 && foundST) {
+        errors.push('Transaction set is not 214');
+      }
+
+      if (!carrierScac) {
+        errors.push('Missing carrier SCAC code in B10 segment');
+      }
+
+      if (!shipmentReference && !proNumber) {
+        errors.push('Missing shipment reference and pro number in B10 segment');
+      }
+
+      if (statusDetails.length === 0) {
+        errors.push('No AT7 status details found');
+      }
+
+      return {
+        success: errors.length === 0,
+        shipmentReference,
+        carrierScac,
+        proNumber,
+        statusDetails,
+        referenceNumbers,
+        weight,
+        rawContent: content,
+        errors,
+      };
+    } catch (err: any) {
+      return {
+        success: false,
+        shipmentReference: '',
+        carrierScac: '',
+        proNumber: '',
+        statusDetails: [],
+        referenceNumbers: [],
+        rawContent: content,
+        errors: [`Parse error: ${err.message}`],
+      };
+    }
+  }
+
+  private finalizePendingStatus(pending: Partial<EDI214StatusDetail>): EDI214StatusDetail {
+    return {
+      statusCode: pending.statusCode || '',
+      reasonCode: pending.reasonCode || '',
+      city: pending.city || '',
+      state: pending.state || '',
+      country: pending.country || '',
+      date: pending.date || '',
+      time: pending.time || '',
+      timeZone: pending.timeZone || '',
+    };
+  }
+}

--- a/backend/src/services/EDI214Service.ts
+++ b/backend/src/services/EDI214Service.ts
@@ -1,0 +1,192 @@
+/**
+ * EDI 214 (Shipment Status Message) Generation Service
+ *
+ * Generates outbound X12 214 documents to report shipment status
+ * to customers or trading partners. Follows the X12 004010 standard.
+ *
+ * Key segments:
+ *   B10  — Shipment identification (reference, SCAC, pro number)
+ *   L11  — Reference numbers
+ *   AT7  — Shipment status detail (status code, reason, date, time)
+ *   MS1  — Equipment location (city, state, country)
+ *   AT8  — Shipment weight and piece count
+ */
+
+export interface EDI214ShipmentData {
+  shipmentReference: string;
+  proNumber?: string;
+  carrierScac: string;
+  /** AT7 status code (AF, X1, D1, A7, etc.) */
+  statusCode: string;
+  /** AT7 reason code */
+  reasonCode?: string;
+  /** Location city */
+  city: string;
+  /** Location state */
+  state: string;
+  /** Location country */
+  country?: string;
+  /** When the status event occurred */
+  statusDate: Date;
+  /** Shipment weight */
+  weight?: number;
+  /** Weight unit (L=lbs, K=kg) */
+  weightUnit?: string;
+  /** Number of pieces */
+  ladingQuantity?: number;
+  /** Additional reference numbers */
+  referenceNumbers?: Array<{ qualifier: string; number: string }>;
+}
+
+export interface EDI214Config {
+  senderId?: string;
+  receiverId?: string;
+  interchangeControlNumber?: string;
+}
+
+export interface IEDI214Service {
+  generateEDI214(data: EDI214ShipmentData, config?: EDI214Config): string;
+}
+
+export class EDI214Service implements IEDI214Service {
+  private segmentTerminator = '~';
+  private elementSeparator = '*';
+  private subElementSeparator = ':';
+
+  generateEDI214(data: EDI214ShipmentData, config?: EDI214Config): string {
+    const segments: string[] = [];
+    const controlNumber = config?.interchangeControlNumber || this.generateControlNumber();
+
+    // ISA — Interchange Control Header
+    segments.push(this.buildISA(config?.senderId || 'OPENTMS', config?.receiverId || data.carrierScac, controlNumber));
+
+    // GS — Functional Group Header (QM = Shipment Status)
+    segments.push(this.buildGS(config?.senderId || 'OPENTMS', config?.receiverId || data.carrierScac, controlNumber));
+
+    // ST — Transaction Set Header (214)
+    segments.push(`ST${this.e}214${this.e}0001`);
+
+    // B10 — Shipment Identification
+    segments.push(`B10${this.e}${this.sanitize(data.shipmentReference)}${this.e}${data.carrierScac}${this.e}${this.sanitize(data.proNumber || data.shipmentReference)}`);
+
+    // L11 — Reference Numbers
+    segments.push(`L11${this.e}${this.sanitize(data.shipmentReference)}${this.e}SI`);
+
+    if (data.referenceNumbers) {
+      for (const ref of data.referenceNumbers) {
+        segments.push(`L11${this.e}${this.sanitize(ref.number)}${this.e}${ref.qualifier}`);
+      }
+    }
+
+    // AT7 — Shipment Status Detail
+    let at7 = `AT7${this.e}${data.statusCode}`;
+    at7 += `${this.e}${data.reasonCode || ''}`;
+    at7 += `${this.e}`;  // AT7-03 unused
+    at7 += `${this.e}`;  // AT7-04 unused
+    at7 += `${this.e}${this.formatDate(data.statusDate)}`;
+    at7 += `${this.e}${this.formatTime(data.statusDate)}`;
+    at7 += `${this.e}LT`; // Local time
+    segments.push(at7);
+
+    // MS1 — Equipment Location
+    segments.push(`MS1${this.e}${this.sanitize(data.city)}${this.e}${data.state || ''}${this.e}${data.country || 'US'}`);
+
+    // AT8 — Shipment Weight
+    if (data.weight) {
+      const unit = (data.weightUnit || 'L').toUpperCase() === 'K' ? 'K' : 'L';
+      let at8 = `AT8${this.e}G${this.e}${unit}${this.e}${data.weight}`;
+      if (data.ladingQuantity) {
+        at8 += `${this.e}${data.ladingQuantity}`;
+      }
+      segments.push(at8);
+    }
+
+    // SE — Transaction Set Trailer
+    const segmentCount = segments.length - 2 + 1; // Exclude ISA/GS, include SE
+    segments.push(`SE${this.e}${segmentCount}${this.e}0001`);
+
+    // GE — Functional Group Trailer
+    segments.push(`GE${this.e}1${this.e}${controlNumber}`);
+
+    // IEA — Interchange Control Trailer
+    segments.push(`IEA${this.e}1${this.e}${controlNumber.padStart(9, '0')}`);
+
+    return segments.map(s => s + this.segmentTerminator).join('\n');
+  }
+
+  // ── Private helpers ──
+
+  private get e(): string {
+    return this.elementSeparator;
+  }
+
+  private buildISA(senderId: string, receiverId: string, controlNumber: string): string {
+    const now = new Date();
+    return [
+      'ISA',
+      '00',                                        // Auth Info Qualifier
+      '          ',                                 // Auth Info (10 chars)
+      '00',                                        // Security Info Qualifier
+      '          ',                                 // Security Info (10 chars)
+      'ZZ',                                        // Sender Qualifier
+      senderId.padEnd(15),                         // Sender ID (15 chars)
+      'ZZ',                                        // Receiver Qualifier
+      receiverId.padEnd(15),                       // Receiver ID (15 chars)
+      this.formatDateISA(now),                     // Date YYMMDD
+      this.formatTimeISA(now),                     // Time HHMM
+      'U',                                         // Repetition Separator
+      '00401',                                     // Version
+      controlNumber.padStart(9, '0'),              // Control Number
+      '0',                                         // Ack Requested
+      'P',                                         // Usage (P=Production)
+      this.subElementSeparator,                    // Sub-element separator
+    ].join(this.elementSeparator);
+  }
+
+  private buildGS(senderId: string, receiverId: string, controlNumber: string): string {
+    const now = new Date();
+    return [
+      'GS',
+      'QM',                                        // Functional ID (QM = Shipment Status)
+      senderId,
+      receiverId,
+      this.formatDate(now),
+      this.formatTime(now),
+      controlNumber,
+      'X',                                         // Responsible Agency
+      '004010',                                    // Version
+    ].join(this.elementSeparator);
+  }
+
+  private formatDate(date: Date): string {
+    const y = date.getFullYear().toString();
+    const m = (date.getMonth() + 1).toString().padStart(2, '0');
+    const d = date.getDate().toString().padStart(2, '0');
+    return `${y}${m}${d}`;
+  }
+
+  private formatDateISA(date: Date): string {
+    const y = date.getFullYear().toString().slice(2);
+    const m = (date.getMonth() + 1).toString().padStart(2, '0');
+    const d = date.getDate().toString().padStart(2, '0');
+    return `${y}${m}${d}`;
+  }
+
+  private formatTime(date: Date): string {
+    const h = date.getHours().toString().padStart(2, '0');
+    const m = date.getMinutes().toString().padStart(2, '0');
+    return `${h}${m}`;
+  }
+
+  private formatTimeISA(date: Date): string {
+    return this.formatTime(date);
+  }
+
+  private sanitize(str: string): string {
+    return str.replace(/[*~:]/g, ' ').trim();
+  }
+
+  private generateControlNumber(): string {
+    return Math.floor(Math.random() * 999999999).toString().padStart(9, '0');
+  }
+}

--- a/backend/src/services/EdiRouterService.ts
+++ b/backend/src/services/EdiRouterService.ts
@@ -35,8 +35,12 @@ const TRANSACTION_ROUTES: Record<string, EdiRouteResult> = {
     endpoint: '/api/v1/edi/997/inbound',
     description: 'Functional Acknowledgment → Track Ack Status',
   },
+  '214': {
+    transactionType: '214',
+    endpoint: '/api/v1/edi/214/inbound',
+    description: 'Shipment Status → Update Tracking',
+  },
   // Future transaction types:
-  // '214': { transactionType: '214', endpoint: '/api/v1/edi/214/inbound', description: 'Shipment Status → Update Tracking' },
   // '210': { transactionType: '210', endpoint: '/api/v1/edi/210/inbound', description: 'Freight Invoice → Create Billing Record' },
 };
 

--- a/backend/src/services/edi214StatusMapping.ts
+++ b/backend/src/services/edi214StatusMapping.ts
@@ -1,0 +1,83 @@
+/**
+ * EDI 214 Status Code Mapping
+ *
+ * Maps X12 214 AT7 status codes to internal Open TMS shipment
+ * and stop statuses. Used by ProcessInbound214Command to
+ * translate carrier status updates into domain state changes.
+ */
+
+export interface StatusMapping {
+  /** Maps to Shipment.status */
+  shipmentStatus: string;
+  /** Maps to ShipmentStop.status (null = no stop update) */
+  stopStatus: string | null;
+  /** What to do with the matched stop */
+  stopAction: 'arrive' | 'depart' | 'complete' | null;
+  /** Human-readable description for ShipmentEvent */
+  eventDescription: string;
+  /** Whether this status represents an exception */
+  isException: boolean;
+  /** Exception type if isException is true */
+  exceptionType?: string;
+}
+
+/**
+ * AT7 status code to internal status mapping.
+ *
+ * Reference: X12 214 Shipment Status Message, AT7 element 01.
+ */
+export const EDI214_STATUS_MAP: Record<string, StatusMapping> = {
+  // Pickup & origin
+  'AF': { shipmentStatus: 'in_transit', stopStatus: null,        stopAction: null,      eventDescription: 'Carrier picked up shipment',         isException: false },
+  'CD': { shipmentStatus: 'in_transit', stopStatus: null,        stopAction: null,      eventDescription: 'Carrier departed origin',             isException: false },
+  'CP': { shipmentStatus: 'in_transit', stopStatus: 'completed', stopAction: 'complete', eventDescription: 'Completed loading at pickup',        isException: false },
+
+  // In-transit
+  'X6': { shipmentStatus: 'in_transit', stopStatus: null,        stopAction: null,      eventDescription: 'En route to delivery',                isException: false },
+  'BA': { shipmentStatus: 'in_transit', stopStatus: null,        stopAction: null,      eventDescription: 'Interline transfer',                  isException: false },
+  'P1': { shipmentStatus: 'in_transit', stopStatus: null,        stopAction: null,      eventDescription: 'Departed terminal',                   isException: false },
+  'OA': { shipmentStatus: 'in_transit', stopStatus: null,        stopAction: null,      eventDescription: 'Out for delivery',                    isException: false },
+  'AG': { shipmentStatus: 'in_transit', stopStatus: null,        stopAction: null,      eventDescription: 'Estimated delivery',                  isException: false },
+
+  // Arrival at facility / intermediate stop
+  'X1': { shipmentStatus: 'in_transit', stopStatus: 'arrived',   stopAction: 'arrive',  eventDescription: 'Arrived at facility',                 isException: false },
+  'X2': { shipmentStatus: 'in_transit', stopStatus: 'completed', stopAction: 'depart',  eventDescription: 'Departed facility',                   isException: false },
+  'X4': { shipmentStatus: 'in_transit', stopStatus: 'completed', stopAction: 'depart',  eventDescription: 'Departed terminal',                   isException: false },
+
+  // Arrival at destination
+  'X3': { shipmentStatus: 'in_transit', stopStatus: 'arrived',   stopAction: 'arrive',  eventDescription: 'Arrived at destination',              isException: false },
+
+  // Delivered
+  'D1': { shipmentStatus: 'delivered',  stopStatus: 'completed', stopAction: 'complete', eventDescription: 'Delivered',                          isException: false },
+
+  // Customs / hold
+  'AV': { shipmentStatus: 'in_transit', stopStatus: null,        stopAction: null,      eventDescription: 'Available for delivery (customs hold)', isException: false },
+
+  // Exceptions
+  'A7': { shipmentStatus: 'exception',  stopStatus: null,        stopAction: null,      eventDescription: 'Refused by consignee',                isException: true, exceptionType: 'refused' },
+  'A9': { shipmentStatus: 'exception',  stopStatus: null,        stopAction: null,      eventDescription: 'Shipment damaged',                    isException: true, exceptionType: 'damage' },
+  'AH': { shipmentStatus: 'exception',  stopStatus: null,        stopAction: null,      eventDescription: 'Attempted delivery, unable to complete', isException: true, exceptionType: 'delay' },
+  'AM': { shipmentStatus: 'exception',  stopStatus: null,        stopAction: null,      eventDescription: 'Carrier delay',                       isException: true, exceptionType: 'delay' },
+};
+
+/**
+ * Look up status mapping for an AT7 code.
+ * Returns null if the code is not recognized.
+ */
+export function mapEdi214Status(statusCode: string): StatusMapping | null {
+  return EDI214_STATUS_MAP[statusCode.toUpperCase()] || null;
+}
+
+/**
+ * Returns a safe default mapping for unrecognized status codes.
+ * Keeps the shipment in its current flow without triggering exceptions.
+ */
+export function getDefaultStatusMapping(statusCode: string): StatusMapping {
+  return {
+    shipmentStatus: 'in_transit',
+    stopStatus: null,
+    stopAction: null,
+    eventDescription: `EDI 214 status: ${statusCode}`,
+    isException: false,
+  };
+}

--- a/docs/DOMAIN_BEHAVIOURS.md
+++ b/docs/DOMAIN_BEHAVIOURS.md
@@ -113,6 +113,7 @@ unassigned → assigned → in_transit → delivered
 | `CreateShipmentCommand` | `POST /api/v1/shipments` | `shipment.created` |
 | `UpdateShipmentCommand` | `PUT /api/v1/shipments/:id` | `shipment.updated`, `shipment.status_changed`, `shipment.carrier_assigned` |
 | `ArchiveShipmentCommand` | `DELETE /api/v1/shipments/:id` | `shipment.archived` |
+| `ProcessInbound214Command` | `POST /api/v1/edi/214/inbound` | `edi_214.received`, `shipment.status_changed`, `shipment.stop_arrived`, `shipment.stop_completed`, `shipment.exception`, `shipment.delivered` |
 
 ### Side Effects
 
@@ -125,6 +126,8 @@ unassigned → assigned → in_transit → delivered
 | `shipment.exception` | — | In-app + email | — |
 | `shipment.stop_arrived` | ShipmentReadModel.stopCount updated | In-app | Orders at stop → delivery_status_changed |
 | `shipment.stop_completed` | ShipmentReadModel.stopCount updated | In-app | Orders at stop → delivered |
+| `edi_214.received` | — | — | Auto-forward outbound 214 to customer trading partners |
+| `edi_214.sent` | — | — | — |
 
 ### Tracking (IoT)
 

--- a/edi-collector/src/collector.ts
+++ b/edi-collector/src/collector.ts
@@ -51,8 +51,8 @@ function detectTransactionType(content: string): string | null {
 const TRANSACTION_ROUTES: Record<string, string> = {
   '850': '/api/v1/orders/import/edi',
   '990': '/api/v1/edi/tender/990',
+  '214': '/api/v1/edi/214/inbound',
   // Future:
-  // '214': '/api/v1/edi/214/inbound',
   // '210': '/api/v1/edi/210/inbound',
 };
 
@@ -299,6 +299,8 @@ export async function collectFromTradingPartner(
           log.info(`[${partner.name}] ${file.name} (850) imported — ${result.data?.ordersCreated || 0} orders created`);
         } else if (txnType === '990') {
           log.info(`[${partner.name}] ${file.name} (990) processed — action: ${result.data?.action || 'unknown'}`);
+        } else if (txnType === '214') {
+          log.info(`[${partner.name}] ${file.name} (214) processed — status: ${result.data?.statusCode || 'unknown'} (${result.data?.action || ''})`);
         } else {
           log.info(`[${partner.name}] ${file.name} (${txnType}) processed`);
         }

--- a/roadmap.md
+++ b/roadmap.md
@@ -371,11 +371,15 @@ The current EDI infrastructure handles inbound 850 (SFTP polling) and outbound 8
   - Support multiple inbound file patterns per partner (*.850, *.990, *.214, *.210)
   - Inbound EDI 997 auto-generation: acknowledge every received transaction
   - Inbound file archival after processing
-- **EDI 214 (Shipment Status) Service** 🔲
-  - Inbound: parse carrier status updates (pickup, in-transit, delivered) → update shipment status
-  - Outbound: generate status messages for customers based on shipment events
-  - Status code mapping: AF (pickup), X1 (in-transit), D1 (delivered), A7 (refused)
-  - Integration with existing ShipmentEvent model
+- **EDI 214 (Shipment Status) Service** ✅
+  - ✅ Inbound: parse carrier status updates (pickup, in-transit, delivered) → update shipment status
+  - ✅ Outbound: generate status messages for customers based on shipment events
+  - ✅ Status code mapping: AF (pickup), X1/X3 (arrived), X6 (en route), D1 (delivered), A7 (refused), A9 (damaged), etc.
+  - ✅ Integration with existing ShipmentEvent model
+  - ✅ Auto-forward inbound 214 to customer trading partners
+  - ✅ Stop-level status updates from AT7+MS1 location matching
+  - ✅ 997 acknowledgment auto-generation for inbound 214
+  - ✅ EDI collector SFTP polling support for 214 files
 - **EDI 210 (Freight Invoice) Service** 🔲
   - Inbound: parse carrier freight invoices → create billing records
   - Three-way matching: tender rate vs shipment status vs invoice amount


### PR DESCRIPTION
Add full inbound and outbound EDI 214 capability, closing the carrier
status tracking loop. Carriers can now report pickup, in-transit,
delivery, and exception statuses via X12 214 documents.

Inbound flow: EDI collector polls SFTP → EdiRouterService detects 214 →
route handler parses via EDI214ParseService → ProcessInbound214Command
updates shipment/stop status → auto-generates 997 acknowledgment →
Edi214ForwardHandler auto-forwards to customer trading partners.

Outbound flow: generate/preview/deliver 214 to customer trading partners
via OutboundEdiDeliveryService (SFTP/HTTP).

New files:
- EDI214ParseService (inbound X12 parsing, B10/AT7/MS1/AT8 segments)
- EDI214Service (outbound X12 generation, GS*QM functional ID)
- edi214StatusMapping (AT7 code → shipment/stop status mapping)
- ProcessInbound214Command (CQRS command with event emission)
- edi214 routes (inbound, generate, preview endpoints)
- Edi214ForwardHandler (auto-forward to customer trading partners)
- 31 tests across 3 test suites (parse, generate, mapping)

https://claude.ai/code/session_017Q1XqfSxRc4oy3dEmgwiZV