### PR TITLE
Add audit events for location creation via resolution (Phase 3b complete)

### DIFF
--- a/backend/src/__tests__/commands/ShipmentLocationResolution.test.ts
+++ b/backend/src/__tests__/commands/ShipmentLocationResolution.test.ts
@@ -125,7 +125,7 @@ describe('CreateShipmentCommand — Location Auto-Resolution', () => {
     expect(result.error).toContain('originData/destinationData');
   });
 
-  it('emits SHIPMENT_CREATED with resolved location IDs', async () => {
+  it('emits LOCATION_CREATED events for auto-created locations then SHIPMENT_CREATED', async () => {
     const { bus } = mockEventBus();
     const handler = new CreateShipmentCommandHandler(mockPrisma, bus, mockQueue);
 
@@ -139,7 +139,118 @@ describe('CreateShipmentCommand — Location Auto-Resolution', () => {
     );
 
     expect(result.success).toBe(true);
+    // Should emit: LOCATION_CREATED (origin) + LOCATION_CREATED (destination) + SHIPMENT_CREATED
+    expect(result.events).toHaveLength(3);
+    expect(result.events[0].type).toBe(EVENT_TYPES.LOCATION_CREATED);
+    expect(result.events[1].type).toBe(EVENT_TYPES.LOCATION_CREATED);
+    expect(result.events[2].type).toBe(EVENT_TYPES.SHIPMENT_CREATED);
+  });
+
+  it('emits LOCATION_CREATED with source "shipment_resolution" and location details', async () => {
+    const { bus } = mockEventBus();
+    const handler = new CreateShipmentCommandHandler(mockPrisma, bus, mockQueue);
+
+    const result = await handler.execute(
+      createTestCommand(CREATE_SHIPMENT, {
+        reference: 'SH-AUTO-004',
+        customerId: 'cust-1',
+        originData: { name: 'Chicago Hub', address1: '100 Main St', city: 'Chicago', country: 'US' },
+        destinationData: { name: 'Dallas DC', address1: '200 Commerce Blvd', city: 'Dallas', country: 'US' },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const locationEvents = result.events.filter(e => e.type === EVENT_TYPES.LOCATION_CREATED);
+    expect(locationEvents).toHaveLength(2);
+
+    // Origin event
+    expect(locationEvents[0].entityType).toBe('location');
+    expect(locationEvents[0].payload).toEqual(expect.objectContaining({
+      locationName: 'Chicago Hub',
+      city: 'Chicago',
+      country: 'US',
+      source: 'shipment_resolution',
+    }));
+
+    // Destination event
+    expect(locationEvents[1].entityType).toBe('location');
+    expect(locationEvents[1].payload).toEqual(expect.objectContaining({
+      locationName: 'Dallas DC',
+      city: 'Dallas',
+      country: 'US',
+      source: 'shipment_resolution',
+    }));
+  });
+
+  it('emits LOCATION_CREATED metadata with actorId and orgId from command', async () => {
+    const { bus } = mockEventBus();
+    const handler = new CreateShipmentCommandHandler(mockPrisma, bus, mockQueue);
+
+    const result = await handler.execute(
+      createTestCommand(CREATE_SHIPMENT, {
+        reference: 'SH-AUTO-005',
+        customerId: 'cust-1',
+        originData: { name: 'WH X', address1: '1 St', city: 'X', country: 'US' },
+        destinationData: { name: 'WH Y', address1: '2 St', city: 'Y', country: 'US' },
+      }, { orgId: 'org-123', actorId: 'user-456' })
+    );
+
+    expect(result.success).toBe(true);
+    const locationEvents = result.events.filter(e => e.type === EVENT_TYPES.LOCATION_CREATED);
+    expect(locationEvents).toHaveLength(2);
+    expect(locationEvents[0].orgId).toBe('org-123');
+    expect(locationEvents[0].actorId).toBe('user-456');
+  });
+
+  it('does NOT emit LOCATION_CREATED when existing locations are matched', async () => {
+    mockTx.location.findFirst
+      .mockResolvedValueOnce({ id: 'existing-origin' })
+      .mockResolvedValueOnce({ id: 'existing-dest' });
+
+    const { bus } = mockEventBus();
+    const handler = new CreateShipmentCommandHandler(mockPrisma, bus, mockQueue);
+
+    const result = await handler.execute(
+      createTestCommand(CREATE_SHIPMENT, {
+        reference: 'SH-AUTO-006',
+        customerId: 'cust-1',
+        originData: { name: 'Existing WH', address1: '1 St', city: 'LA', country: 'US' },
+        destinationData: { name: 'Existing DC', address1: '2 St', city: 'NYC', country: 'US' },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    // Only SHIPMENT_CREATED, no LOCATION_CREATED
     expect(result.events).toHaveLength(1);
     expect(result.events[0].type).toBe(EVENT_TYPES.SHIPMENT_CREATED);
+  });
+
+  it('emits LOCATION_CREATED only for the newly created location in mixed scenario', async () => {
+    mockTx.location.findFirst
+      .mockResolvedValueOnce({ id: 'existing-origin' }) // origin found
+      .mockResolvedValueOnce(null); // destination not found
+    mockTx.location.create.mockResolvedValueOnce({ id: 'new-dest' });
+
+    const { bus } = mockEventBus();
+    const handler = new CreateShipmentCommandHandler(mockPrisma, bus, mockQueue);
+
+    const result = await handler.execute(
+      createTestCommand(CREATE_SHIPMENT, {
+        reference: 'SH-AUTO-007',
+        customerId: 'cust-1',
+        originData: { name: 'Existing WH', address1: '1 St', city: 'LA', country: 'US' },
+        destinationData: { name: 'New DC', address1: '2 St', city: 'NYC', country: 'US' },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    // LOCATION_CREATED (destination only) + SHIPMENT_CREATED
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0].type).toBe(EVENT_TYPES.LOCATION_CREATED);
+    expect(result.events[0].payload).toEqual(expect.objectContaining({
+      locationName: 'New DC',
+      source: 'shipment_resolution',
+    }));
+    expect(result.events[1].type).toBe(EVENT_TYPES.SHIPMENT_CREATED);
   });
 });

--- a/backend/src/__tests__/services/LocationResolutionService.test.ts
+++ b/backend/src/__tests__/services/LocationResolutionService.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for LocationResolutionService — audit event emission on location
+ * auto-creation via resolution.
+ */
+
+import { LocationResolutionService } from '../../services/LocationResolutionService';
+import { EVENT_TYPES } from '../../events/eventTypes';
+
+const mockLocation = {
+  id: 'loc-new-1',
+  name: 'Test Warehouse',
+  address1: '123 Main St',
+  city: 'Chicago',
+  state: 'IL',
+  country: 'US',
+  lat: 41.8,
+  lng: -87.6,
+  archived: false,
+};
+
+const mockLocationsRepo = {
+  create: jest.fn().mockResolvedValue(mockLocation),
+  findById: jest.fn().mockResolvedValue(mockLocation),
+} as any;
+
+const mockArrivalCriteriaRepo = {
+  findByLocationId: jest.fn().mockResolvedValue([]),
+  createDefaultGeofence: jest.fn().mockResolvedValue({}),
+} as any;
+
+const mockPrisma = {
+  location: {
+    findFirst: jest.fn().mockResolvedValue(null),
+  },
+  organization: {
+    findFirst: jest.fn().mockResolvedValue({ id: 'org-1', defaultGeofenceRadiusMeters: 200 }),
+  },
+} as any;
+
+const mockEventBus = {
+  publish: jest.fn().mockResolvedValue(undefined),
+  publishBatch: jest.fn().mockResolvedValue(undefined),
+  subscribe: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+} as any;
+
+describe('LocationResolutionService — Audit Events', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrisma.location.findFirst.mockResolvedValue(null);
+    mockLocationsRepo.create.mockResolvedValue(mockLocation);
+  });
+
+  it('emits LOCATION_CREATED event when a new location is created', async () => {
+    const service = new LocationResolutionService(
+      mockPrisma,
+      mockLocationsRepo,
+      mockArrivalCriteriaRepo,
+      mockEventBus,
+    );
+
+    const result = await service.resolveOrCreate({
+      name: 'Test Warehouse',
+      address1: '123 Main St',
+      city: 'Chicago',
+      country: 'US',
+    }, 'user-1');
+
+    expect(result.created).toBe(true);
+    expect(mockEventBus.publish).toHaveBeenCalledTimes(1);
+
+    const publishedEvent = mockEventBus.publish.mock.calls[0][0];
+    expect(publishedEvent.type).toBe(EVENT_TYPES.LOCATION_CREATED);
+    expect(publishedEvent.entityType).toBe('location');
+    expect(publishedEvent.entityId).toBe('loc-new-1');
+    expect(publishedEvent.payload).toEqual(expect.objectContaining({
+      locationName: 'Test Warehouse',
+      name: 'Test Warehouse',
+      city: 'Chicago',
+      country: 'US',
+      source: 'resolution',
+    }));
+  });
+
+  it('includes actorId in the emitted event', async () => {
+    const service = new LocationResolutionService(
+      mockPrisma,
+      mockLocationsRepo,
+      mockArrivalCriteriaRepo,
+      mockEventBus,
+    );
+
+    await service.resolveOrCreate({
+      name: 'Test Warehouse',
+      address1: '123 Main St',
+      city: 'Chicago',
+      country: 'US',
+    }, 'user-42');
+
+    const publishedEvent = mockEventBus.publish.mock.calls[0][0];
+    expect(publishedEvent.actorId).toBe('user-42');
+  });
+
+  it('includes orgId from the database in the emitted event', async () => {
+    const service = new LocationResolutionService(
+      mockPrisma,
+      mockLocationsRepo,
+      mockArrivalCriteriaRepo,
+      mockEventBus,
+    );
+
+    await service.resolveOrCreate({
+      name: 'Test Warehouse',
+      address1: '123 Main St',
+      city: 'Chicago',
+      country: 'US',
+    });
+
+    const publishedEvent = mockEventBus.publish.mock.calls[0][0];
+    expect(publishedEvent.orgId).toBe('org-1');
+  });
+
+  it('does NOT emit event when an existing location is matched', async () => {
+    mockPrisma.location.findFirst.mockResolvedValue(mockLocation);
+
+    const service = new LocationResolutionService(
+      mockPrisma,
+      mockLocationsRepo,
+      mockArrivalCriteriaRepo,
+      mockEventBus,
+    );
+
+    const result = await service.resolveOrCreate({
+      name: 'Test Warehouse',
+      address1: '123 Main St',
+      city: 'Chicago',
+      country: 'US',
+    });
+
+    expect(result.created).toBe(false);
+    expect(mockEventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('still creates location successfully if event bus publish fails', async () => {
+    mockEventBus.publish.mockRejectedValueOnce(new Error('Bus unavailable'));
+
+    const service = new LocationResolutionService(
+      mockPrisma,
+      mockLocationsRepo,
+      mockArrivalCriteriaRepo,
+      mockEventBus,
+    );
+
+    const result = await service.resolveOrCreate({
+      name: 'Test Warehouse',
+      address1: '123 Main St',
+      city: 'Chicago',
+      country: 'US',
+    });
+
+    // Location creation should succeed despite event failure
+    expect(result.created).toBe(true);
+    expect(result.location.id).toBe('loc-new-1');
+  });
+
+  it('works without event bus (backward compatible)', async () => {
+    const service = new LocationResolutionService(
+      mockPrisma,
+      mockLocationsRepo,
+      mockArrivalCriteriaRepo,
+      // No event bus provided
+    );
+
+    const result = await service.resolveOrCreate({
+      name: 'Test Warehouse',
+      address1: '123 Main St',
+      city: 'Chicago',
+      country: 'US',
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.location.id).toBe('loc-new-1');
+    // No event bus → no publish call → no error
+  });
+
+  it('sets event metadata source to "resolution"', async () => {
+    const service = new LocationResolutionService(
+      mockPrisma,
+      mockLocationsRepo,
+      mockArrivalCriteriaRepo,
+      mockEventBus,
+    );
+
+    await service.resolveOrCreate({
+      name: 'Test Warehouse',
+      address1: '123 Main St',
+      city: 'Chicago',
+      country: 'US',
+    });
+
+    const publishedEvent = mockEventBus.publish.mock.calls[0][0];
+    expect(publishedEvent.metadata.source).toBe('resolution');
+  });
+});

--- a/backend/src/commands/shipments/CreateShipmentCommand.ts
+++ b/backend/src/commands/shipments/CreateShipmentCommand.ts
@@ -126,6 +126,20 @@ export class CreateShipmentCommandHandler extends BaseCommandHandler<CreateShipm
           },
         });
         finalOriginId = created.id;
+
+        // Emit audit event for auto-created location
+        emit(this.createEvent(command, {
+          type: EVENT_TYPES.LOCATION_CREATED,
+          entityType: 'location',
+          entityId: created.id,
+          payload: {
+            locationName: body.originData.name,
+            name: body.originData.name,
+            city: body.originData.city,
+            country: body.originData.country,
+            source: 'shipment_resolution',
+          },
+        }));
       }
     }
 
@@ -155,6 +169,20 @@ export class CreateShipmentCommandHandler extends BaseCommandHandler<CreateShipm
           },
         });
         finalDestinationId = created.id;
+
+        // Emit audit event for auto-created location
+        emit(this.createEvent(command, {
+          type: EVENT_TYPES.LOCATION_CREATED,
+          entityType: 'location',
+          entityId: created.id,
+          payload: {
+            locationName: body.destinationData.name,
+            name: body.destinationData.name,
+            city: body.destinationData.city,
+            country: body.destinationData.country,
+            source: 'shipment_resolution',
+          },
+        }));
       }
     }
 

--- a/backend/src/di/registry.ts
+++ b/backend/src/di/registry.ts
@@ -168,7 +168,8 @@ export function registerDependencies(prisma: PrismaClient): void {
     return new LocationResolutionService(
       container.resolve(TOKENS.PrismaClient),
       container.resolve(TOKENS.ILocationsRepository),
-      container.resolve(TOKENS.IArrivalCriteriaRepository)
+      container.resolve(TOKENS.IArrivalCriteriaRepository),
+      container.resolve(TOKENS.IEventBus)
     );
   });
 

--- a/backend/src/routes/locations.ts
+++ b/backend/src/routes/locations.ts
@@ -80,15 +80,19 @@ export async function locationRoutes(server: FastifyInstance) {
       })
       .parse((req as any).body);
 
-    // Use resolution service to create with default arrival criteria
+    // Use resolution service to create with default arrival criteria.
+    // The service emits LOCATION_CREATED for new locations automatically.
+    // For existing locations (resolved, not created), publish LOCATION_UPDATED.
     const result = await locationResolutionService.resolveOrCreate(body, req.user?.sub);
 
-    await publishLocationEvent(
-      result.created ? EVENT_TYPES.LOCATION_CREATED : EVENT_TYPES.LOCATION_UPDATED,
-      result.location.id,
-      { locationName: result.location.name, source: 'manual', created: result.created },
-      req.user?.sub,
-    );
+    if (!result.created) {
+      await publishLocationEvent(
+        EVENT_TYPES.LOCATION_UPDATED,
+        result.location.id,
+        { locationName: result.location.name, source: 'manual', created: false },
+        req.user?.sub,
+      );
+    }
 
     reply.code(result.created ? 201 : 200);
     // Fetch with arrival criteria

--- a/backend/src/services/LocationResolutionService.ts
+++ b/backend/src/services/LocationResolutionService.ts
@@ -10,6 +10,9 @@
 import { PrismaClient, Location } from '@prisma/client';
 import { ILocationsRepository, CreateLocationDTO } from '../repositories/LocationsRepository.js';
 import { IArrivalCriteriaRepository } from '../repositories/ArrivalCriteriaRepository.js';
+import { IEventBus } from '../events/IEventBus.js';
+import { createEvent } from '../events/createEvent.js';
+import { EVENT_TYPES } from '../events/eventTypes.js';
 
 export interface RawLocationData {
   name: string;
@@ -48,9 +51,10 @@ export class LocationResolutionService implements ILocationResolutionService {
     private prisma: PrismaClient,
     private locationsRepo: ILocationsRepository,
     private arrivalCriteriaRepo: IArrivalCriteriaRepository,
+    private eventBus?: IEventBus,
   ) {}
 
-  async resolveOrCreate(data: RawLocationData, _actorId?: string): Promise<LocationResolutionResult> {
+  async resolveOrCreate(data: RawLocationData, actorId?: string): Promise<LocationResolutionResult> {
     // Try to find an existing location by name + city match
     const existing = await this.prisma.location.findFirst({
       where: {
@@ -83,7 +87,7 @@ export class LocationResolutionService implements ILocationResolutionService {
 
     // Create default geofence arrival criteria
     const org = await this.prisma.organization.findFirst({
-      select: { defaultGeofenceRadiusMeters: true },
+      select: { id: true, defaultGeofenceRadiusMeters: true },
     });
     const defaultRadius = org?.defaultGeofenceRadiusMeters ?? 200;
 
@@ -93,6 +97,30 @@ export class LocationResolutionService implements ILocationResolutionService {
       location.lat ?? undefined,
       location.lng ?? undefined,
     );
+
+    // Emit audit event for location created via resolution
+    if (this.eventBus) {
+      try {
+        await this.eventBus.publish(createEvent({
+          type: EVENT_TYPES.LOCATION_CREATED,
+          orgId: org?.id || 'default',
+          actorId: actorId ?? null,
+          entityType: 'location',
+          entityId: location.id,
+          payload: {
+            locationName: location.name,
+            name: location.name,
+            city: location.city,
+            country: location.country,
+            source: 'resolution',
+          },
+          source: 'resolution',
+        }));
+      } catch (err) {
+        // Non-critical — location is created, audit is best-effort
+        console.warn(`[LocationResolution] Failed to publish location.created event: ${(err as Error).message}`);
+      }
+    }
 
     return { location, created: true };
   }

--- a/docs/DOMAIN_BEHAVIOURS.md
+++ b/docs/DOMAIN_BEHAVIOURS.md
@@ -198,6 +198,8 @@ Locations can be classified by type (`warehouse`, `distribution_centre`, `cross_
 |---------|---------|----------------|-------------|
 | `CreateLocationCommand` | `POST /api/v1/locations` | `location.created` | Event payload includes `locationType` |
 | `UpdateLocationCommand` | `PUT /api/v1/locations/:id` | `location.updated` | Event payload includes changed field names |
+| `CreateShipmentCommand` (resolution) | Shipment with `originData`/`destinationData` | `location.created` | `source: 'shipment_resolution'` in payload |
+| `LocationResolutionService` | Order creation, EDI import | `location.created` | `source: 'resolution'` in payload |
 
 ---
 
@@ -743,8 +745,13 @@ When `autoCreateIssue = true` on the rule:
 When `CreateShipmentCommand` receives `originData`/`destinationData` (raw address objects) instead of explicit location IDs:
 1. Searches for existing location by `name + city` (case-insensitive)
 2. If found, reuses the existing location
-3. If not found, creates a new `Location` record
+3. If not found, creates a new `Location` record and emits `location.created` with `source: 'shipment_resolution'`
 4. Default geofence arrival criteria are created for new locations (via `LocationResolutionService`)
+
+When `LocationResolutionService.resolveOrCreate()` creates a new location (used by order creation, EDI import):
+- Emits `location.created` with `source: 'resolution'` and the actor's ID
+- Event is best-effort (location creation succeeds even if event publishing fails)
+- The `AuditHandler` records the source in the audit log description
 
 ### Workers
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -130,7 +130,7 @@
   - ✅ Arrival criteria management API (CRUD per location)
   - ✅ Configurable default geofence radius at organization level (Admin > Settings)
   - ✅ CreateShipmentCommand accepts originData/destinationData for auto-resolution
-  - Audit events for location creation via resolution 🔲
+  - Audit events for location creation via resolution ✅
 - **Shipment Completion Criteria** ✅
   - ✅ ShipmentCompletionHandler: auto-delivers when destination arrival criteria met
   - ✅ Listens to shipment.stop_arrived and tracking.geofence_entered events


### PR DESCRIPTION
When locations are auto-created during shipment creation or order/EDI import,
LOCATION_CREATED events are now emitted with source tracking so the audit
trail captures how and why each location was created.

- CreateShipmentCommand emits location.created with source: 'shipment_resolution'
- LocationResolutionService emits location.created with source: 'resolution'
- LocationResolutionService now receives IEventBus via DI
- Locations route no longer double-emits on creation (service handles it)
- 8 new tests covering event emission, metadata propagation, error resilience
- Updated DOMAIN_BEHAVIOURS.md and roadmap.md

https://claude.ai/code/session_013NA85eUz7fXPU2uQXBnPtS