### PR TITLE
Add LinkedIn profile link to marketing website

### DIFF
--- a/www/src/components/Footer.tsx
+++ b/www/src/components/Footer.tsx
@@ -41,6 +41,7 @@ export default function Footer() {
               <li><a href="https://github.com/dominicfinn/open_tms/issues" target="_blank" rel="noopener noreferrer" className="text-sm text-surface-400 hover:text-white transition-colors">Issues</a></li>
               <li><a href="https://github.com/dominicfinn/open_tms/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" className="text-sm text-surface-400 hover:text-white transition-colors">Contributing</a></li>
               <li><Link to="/blog" className="text-sm text-surface-400 hover:text-white transition-colors">Blog</Link></li>
+              <li><a href="https://www.linkedin.com/in/dominicfinn?utm_source=opentms" target="_blank" rel="noopener noreferrer" className="text-sm text-surface-400 hover:text-white transition-colors">LinkedIn</a></li>
             </ul>
           </div>
 
@@ -59,9 +60,13 @@ export default function Footer() {
           <p className="text-sm text-surface-500">
             &copy; {new Date().getFullYear()} Open TMS. Released under the MIT License.
           </p>
-          <p className="text-sm text-surface-500">
-            Integrates with System Loco IoT hardware
-          </p>
+          <div className="flex items-center gap-4 text-sm text-surface-500">
+            <span>Integrates with System Loco IoT hardware</span>
+            <span className="hidden sm:inline">·</span>
+            <a href="https://www.linkedin.com/in/dominicfinn?utm_source=opentms" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">
+              Maintained by Dominic Finn
+            </a>
+          </div>
         </div>
       </div>
     </footer>

--- a/www/src/components/OpenSource.tsx
+++ b/www/src/components/OpenSource.tsx
@@ -29,8 +29,6 @@ const benefits = [
   {
     title: 'Consultancy Available',
     description: 'Need help with a private fork, custom integrations, or complex deployments? Professional installation, setup, and ongoing support is available.',
-    link: 'https://www.linkedin.com/in/dominicfinn?utm_source=opentms',
-    linkLabel: 'Get in touch via LinkedIn',
     icon: (
       <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />

--- a/www/src/components/OpenSource.tsx
+++ b/www/src/components/OpenSource.tsx
@@ -29,6 +29,8 @@ const benefits = [
   {
     title: 'Consultancy Available',
     description: 'Need help with a private fork, custom integrations, or complex deployments? Professional installation, setup, and ongoing support is available.',
+    link: 'https://www.linkedin.com/in/dominicfinn?utm_source=opentms',
+    linkLabel: 'Get in touch via LinkedIn',
     icon: (
       <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
@@ -81,6 +83,14 @@ export default function OpenSource() {
               </div>
               <h3 className="text-lg font-semibold text-white mb-3">{benefit.title}</h3>
               <p className="text-sm text-surface-400 leading-relaxed">{benefit.description}</p>
+              {benefit.link && (
+                <a href={benefit.link} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-sm font-medium text-primary-400 hover:text-primary-300 transition-colors mt-3">
+                  {benefit.linkLabel}
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                  </svg>
+                </a>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
Adds Dominic Finn's LinkedIn profile to three places:
- Footer Community column as a "LinkedIn" link
- Footer bottom bar as a "Maintained by Dominic Finn" credit
- OpenSource section Consultancy card with a "Get in touch via LinkedIn" CTA

https://claude.ai/code/session_01AFZeLEYukjWgZppjWwNUqh