### PR TITLE
Fix 7 bugs from GitHub issues #20, #21, #22, #24, #25, #26, #27

### DIFF
--- a/backend/src/commands/BaseCommandHandler.ts
+++ b/backend/src/commands/BaseCommandHandler.ts
@@ -54,7 +54,7 @@ export abstract class BaseCommandHandler<TPayload = unknown, TResult = unknown>
     }
 
     try {
-      const data = await this.prisma.$transaction(async (tx) => {
+      const data = await this.prisma.$transaction(async (tx: TransactionClient) => {
         // Execute the command handler logic
         const result = await this.handle(command, tx, emit);
 

--- a/backend/src/queue/PgBossQueueAdapter.ts
+++ b/backend/src/queue/PgBossQueueAdapter.ts
@@ -134,23 +134,8 @@ export class PgBossQueueAdapter implements IQueueAdapter {
   }
 
   async peekJobs(queueName: string, state: 'queued' | 'active' | 'failed', limit: number = 20): Promise<QueueJob[]> {
-    try {
-      const targetQueue = state === 'failed' ? queueName + DEAD_LETTER_SUFFIX : queueName;
-
-      const jobs = await this.boss.fetch(targetQueue, {
-        includeMetadata: true,
-        batchSize: limit,
-      } as any);
-
-      if (!jobs || jobs.length === 0) return [];
-
-      // We fetched these jobs, so we need to put them back (complete without processing)
-      // Actually, fetch removes them from the queue. For peeking we should use findJobs or direct SQL.
-      // Let's use findJobs instead.
-      return [];
-    } catch {
-      return [];
-    }
+    // Delegate to the non-destructive implementation
+    return this.peekJobsDirect(queueName, state, limit);
   }
 
   async purgeQueue(queueName: string): Promise<number> {

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -91,10 +91,15 @@ export const createOrderSchema = z.object({
   notes: z.string().optional()
 });
 
+const ORDER_STATUSES = ['pending', 'validated', 'location_error', 'converted', 'cancelled', 'archived'] as const;
+const DELIVERY_STATUSES = ['unassigned', 'assigned', 'in_transit', 'delivered', 'exception', 'cancelled'] as const;
+const DELIVERY_METHODS = ['manual', 'geofence', 'geofence_iot', 'auto', 'driver_app'] as const;
+const EXCEPTION_TYPES = ['delay', 'damage', 'refused', 'address_issue', 'weather', 'other'] as const;
+
 const updateOrderSchema = z.object({
   orderNumber: z.string().min(1).optional(),
   poNumber: z.string().optional(),
-  status: z.string().optional(),
+  status: z.enum(ORDER_STATUSES).optional(),
   originId: z.string().uuid().optional(),
   destinationId: z.string().uuid().optional(),
   requestedPickupDate: z.string().datetime().optional(),
@@ -720,23 +725,32 @@ export async function orderRoutes(server: FastifyInstance) {
   // Update order delivery status
   server.post('/api/v1/orders/:id/delivery-status', async (req: FastifyRequest, reply: FastifyReply) => {
     const { id } = req.params as { id: string };
-    const body = req.body as {
-      deliveryStatus: string;
-      deliveryMethod?: string;
-      deliveryConfirmedBy?: string;
-      deliveryNotes?: string;
-      exceptionType?: string;
-      exceptionNotes?: string;
-    };
+
+    const deliveryStatusSchema = z.object({
+      deliveryStatus: z.enum(DELIVERY_STATUSES),
+      deliveryMethod: z.enum(DELIVERY_METHODS).optional(),
+      deliveryConfirmedBy: z.string().optional(),
+      deliveryNotes: z.string().optional(),
+      exceptionType: z.enum(EXCEPTION_TYPES).optional(),
+      exceptionNotes: z.string().optional(),
+    });
+
+    const parsed = deliveryStatusSchema.safeParse(req.body);
+    if (!parsed.success) {
+      reply.code(400);
+      return { data: null, error: parsed.error.issues.map(i => i.message).join(', ') };
+    }
+
+    const body = parsed.data;
 
     try {
       const updatedOrder = await deliveryService.updateOrderDeliveryStatus({
         orderId: id,
-        deliveryStatus: body.deliveryStatus as any,
-        deliveryMethod: body.deliveryMethod as any,
+        deliveryStatus: body.deliveryStatus,
+        deliveryMethod: body.deliveryMethod,
         deliveryConfirmedBy: body.deliveryConfirmedBy,
         deliveryNotes: body.deliveryNotes,
-        exceptionType: body.exceptionType as any,
+        exceptionType: body.exceptionType,
         exceptionNotes: body.exceptionNotes
       });
 
@@ -774,16 +788,25 @@ export async function orderRoutes(server: FastifyInstance) {
   // Create delivery exception
   server.post('/api/v1/orders/:id/delivery-exception', async (req: FastifyRequest, reply: FastifyReply) => {
     const { id } = req.params as { id: string };
-    const body = req.body as {
-      exceptionType: string;
-      exceptionNotes: string;
-      reportedBy?: string;
-    };
+
+    const exceptionSchema = z.object({
+      exceptionType: z.enum(EXCEPTION_TYPES),
+      exceptionNotes: z.string(),
+      reportedBy: z.string().optional(),
+    });
+
+    const parsed = exceptionSchema.safeParse(req.body);
+    if (!parsed.success) {
+      reply.code(400);
+      return { data: null, error: parsed.error.issues.map(i => i.message).join(', ') };
+    }
+
+    const body = parsed.data;
 
     try {
       const updatedOrder = await deliveryService.createDeliveryException({
         orderId: id,
-        exceptionType: body.exceptionType as any,
+        exceptionType: body.exceptionType,
         exceptionNotes: body.exceptionNotes,
         reportedBy: body.reportedBy
       });

--- a/backend/src/services/ConsolidationBillingService.ts
+++ b/backend/src/services/ConsolidationBillingService.ts
@@ -41,6 +41,7 @@ export class ConsolidationBillingService implements IConsolidationBillingService
           select: {
             id: true,
             orderNumber: true,
+            customerId: true,
             lineItems: {
               select: { weight: true, quantity: true },
             },
@@ -51,6 +52,17 @@ export class ConsolidationBillingService implements IConsolidationBillingService
 
     if (orderShipments.length === 0) {
       throw new Error('No orders found on this shipment');
+    }
+
+    // Validate all orders belong to the same customer
+    const customerIds = new Set(
+      orderShipments.map(os => os.order.customerId).filter(Boolean)
+    );
+    if (customerIds.size > 1) {
+      throw new Error(
+        'Cannot pro-rate costs: shipment contains orders from multiple customers. ' +
+        'LTL consolidation must only combine orders from the same customer.'
+      );
     }
 
     // Calculate weight per order

--- a/backend/src/services/OrderDeliveryService.ts
+++ b/backend/src/services/OrderDeliveryService.ts
@@ -232,116 +232,121 @@ export class OrderDeliveryService implements IOrderDeliveryService {
       throw new Error('Shipment stop not found');
     }
 
-    // Update stop status
-    await this.prisma.shipmentStop.update({
-      where: { id: shipmentStopId },
-      data: {
-        status,
-        actualArrival: status === 'arrived' || status === 'in_progress' || status === 'completed' ? new Date() : stop.actualArrival,
-        actualDeparture: status === 'completed' ? new Date() : stop.actualDeparture,
-        updatedAt: new Date()
+    // Wrap stop status + order updates in a transaction for atomicity
+    const result = await this.prisma.$transaction(async (tx) => {
+      // Update stop status
+      await tx.shipmentStop.update({
+        where: { id: shipmentStopId },
+        data: {
+          status,
+          actualArrival: status === 'arrived' || status === 'in_progress' || status === 'completed' ? new Date() : stop.actualArrival,
+          actualDeparture: status === 'completed' ? new Date() : stop.actualDeparture,
+          updatedAt: new Date()
+        }
+      });
+
+      // If stop is completed, mark all orders at this stop as delivered
+      if (status === 'completed') {
+        const affectedOrders = stop.orders;
+        const updateResult = await tx.order.updateMany({
+          where: {
+            deliveryStopId: shipmentStopId,
+            deliveryStatus: {
+              notIn: ['delivered', 'cancelled']
+            }
+          },
+          data: {
+            deliveryStatus: 'delivered',
+            deliveredAt: new Date(),
+            deliveryMethod: method,
+            deliveryConfirmedBy: 'system:shipment_stop_completed',
+            updatedAt: new Date()
+          }
+        });
+
+        // Audit log for each affected order
+        for (const o of affectedOrders) {
+          await tx.auditLog.create({
+            data: {
+              entityType: 'order',
+              entityId: o.id,
+              orderId: o.id,
+              action: 'delivery_status_changed',
+              description: `Order delivered at stop (${stop.location?.name || 'unknown'}) via ${method}`,
+              changes: {
+                before: { deliveryStatus: o.deliveryStatus },
+                after: { deliveryStatus: 'delivered' }
+              },
+            }
+          });
+        }
+
+        return updateResult.count;
       }
+
+      // If stop is in_progress or arrived, mark orders as in_transit
+      if (status === 'arrived' || status === 'in_progress') {
+        const affectedOrders = stop.orders.filter(
+          (o: any) => o.deliveryStatus === 'assigned' || o.deliveryStatus === 'unassigned'
+        );
+        const updateResult = await tx.order.updateMany({
+          where: {
+            deliveryStopId: shipmentStopId,
+            deliveryStatus: {
+              in: ['assigned', 'unassigned']
+            }
+          },
+          data: {
+            deliveryStatus: 'in_transit',
+            deliveryMethod: method,
+            updatedAt: new Date()
+          }
+        });
+
+        for (const o of affectedOrders) {
+          await tx.auditLog.create({
+            data: {
+              entityType: 'order',
+              entityId: o.id,
+              orderId: o.id,
+              action: 'delivery_status_changed',
+              description: `Order in transit - stop ${status} (${stop.location?.name || 'unknown'}) via ${method}`,
+              changes: {
+                before: { deliveryStatus: o.deliveryStatus },
+                after: { deliveryStatus: 'in_transit' }
+              },
+            }
+          });
+        }
+
+        return updateResult.count;
+      }
+
+      return 0;
     });
 
-    // If stop is completed, mark all orders at this stop as delivered
-    if (status === 'completed') {
-      const affectedOrders = stop.orders;
-      const updateResult = await this.prisma.order.updateMany({
-        where: {
-          deliveryStopId: shipmentStopId,
-          deliveryStatus: {
-            notIn: ['delivered', 'cancelled']
-          }
-        },
-        data: {
-          deliveryStatus: 'delivered',
-          deliveredAt: new Date(),
-          deliveryMethod: method,
-          deliveryConfirmedBy: 'system:shipment_stop_completed',
-          updatedAt: new Date()
-        }
-      });
+    // Cargo reconciliation runs outside the transaction (non-blocking side effect)
+    if (status === 'completed' && this.cargoReconciliation) {
+      try {
+        await this.cargoReconciliation.autoReconcileStop(shipmentStopId, method);
+        await this.cargoReconciliation.reconcileStopCompletion(shipmentStopId);
 
-      // Audit log for each affected order
-      for (const o of affectedOrders) {
-        await this.prisma.auditLog.create({
-          data: {
-            entityType: 'order',
-            entityId: o.id,
-            orderId: o.id,
-            action: 'delivery_status_changed',
-            description: `Order delivered at stop (${stop.location?.name || 'unknown'}) via ${method}`,
-            changes: {
-              before: { deliveryStatus: o.deliveryStatus },
-              after: { deliveryStatus: 'delivered' }
-            },
-          }
+        // If this was the last stop, check for cargo left on vehicle
+        const allStops = await this.prisma.shipmentStop.findMany({
+          where: { shipmentId: stop.shipmentId },
         });
-      }
-
-      // Cargo reconciliation: auto-record scans and reconcile for misdrop detection
-      if (this.cargoReconciliation) {
-        try {
-          await this.cargoReconciliation.autoReconcileStop(shipmentStopId, method);
-          await this.cargoReconciliation.reconcileStopCompletion(shipmentStopId);
-
-          // If this was the last stop, check for cargo left on vehicle
-          const allStops = await this.prisma.shipmentStop.findMany({
-            where: { shipmentId: stop.shipmentId },
-          });
-          const allCompleted = allStops.every(
-            (s) => s.id === shipmentStopId || s.status === 'completed' || s.status === 'skipped'
-          );
-          if (allCompleted) {
-            await this.cargoReconciliation.checkLeftOnVehicle(stop.shipmentId);
-          }
-        } catch (err) {
-          console.error('[OrderDeliveryService] Cargo reconciliation failed (non-blocking):', err);
+        const allCompleted = allStops.every(
+          (s) => s.id === shipmentStopId || s.status === 'completed' || s.status === 'skipped'
+        );
+        if (allCompleted) {
+          await this.cargoReconciliation.checkLeftOnVehicle(stop.shipmentId);
         }
+      } catch (err) {
+        console.error('[OrderDeliveryService] Cargo reconciliation failed (non-blocking):', err);
       }
-
-      return updateResult.count;
     }
 
-    // If stop is in_progress or arrived, mark orders as in_transit
-    if (status === 'arrived' || status === 'in_progress') {
-      const affectedOrders = stop.orders.filter(
-        (o: any) => o.deliveryStatus === 'assigned' || o.deliveryStatus === 'unassigned'
-      );
-      const updateResult = await this.prisma.order.updateMany({
-        where: {
-          deliveryStopId: shipmentStopId,
-          deliveryStatus: {
-            in: ['assigned', 'unassigned']
-          }
-        },
-        data: {
-          deliveryStatus: 'in_transit',
-          deliveryMethod: method,
-          updatedAt: new Date()
-        }
-      });
-
-      for (const o of affectedOrders) {
-        await this.prisma.auditLog.create({
-          data: {
-            entityType: 'order',
-            entityId: o.id,
-            orderId: o.id,
-            action: 'delivery_status_changed',
-            description: `Order in transit — stop ${status} (${stop.location?.name || 'unknown'}) via ${method}`,
-            changes: {
-              before: { deliveryStatus: o.deliveryStatus },
-              after: { deliveryStatus: 'in_transit' }
-            },
-          }
-        });
-      }
-
-      return updateResult.count;
-    }
-
-    return 0;
+    return result;
   }
 
   /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -90,7 +90,9 @@ export interface Vehicle extends Timestamped {
   carrierId: ID;
   plate: string;
   type: "van" | "box_truck" | "semi" | "container";
+  /** Capacity in whole kilograms (matches Prisma Int type) */
   capacityKg?: number;
+  /** Capacity in whole cubic metres (matches Prisma Int type) */
   capacityM3?: number;
 }
 

--- a/webhook-service/prisma/schema.prisma
+++ b/webhook-service/prisma/schema.prisma
@@ -7,39 +7,9 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Customer {
-  id           String   @id @default(uuid())
-  name         String
-  contactEmail String?
-  archived     Boolean  @default(false)
-  archivedAt   DateTime?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  shipments    Shipment[]
-  customerLanes CustomerLane[]
-}
-
-model Location {
-  id         String   @id @default(uuid())
-  name       String
-  address1   String
-  address2   String?
-  city       String
-  state      String?
-  postalCode String?
-  country    String
-  lat        Float?
-  lng        Float?
-  archived   Boolean  @default(false)
-  archivedAt DateTime?
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-  originFor  Shipment[] @relation("Origin")
-  destFor    Shipment[] @relation("Destination")
-  lanesAsOrigin Lane[] @relation("LaneOrigin")
-  lanesAsDestination Lane[] @relation("LaneDestination")
-  laneStops  LaneStop[]
-}
+// The webhook-service only needs read access to Shipment (lookup by reference)
+// and write access to ShipmentEvent (recording location events from IoT webhooks).
+// All other models are managed by the main backend service.
 
 model Shipment {
   id            String   @id @default(uuid())
@@ -52,144 +22,12 @@ model Shipment {
   archivedAt    DateTime?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
-  customer      Customer @relation(fields: [customerId], references: [id])
   customerId    String
-  origin        Location @relation("Origin", fields: [originId], references: [id])
   originId      String
-  destination   Location @relation("Destination", fields: [destinationId], references: [id])
   destinationId String
-  lane          Lane?    @relation(fields: [laneId], references: [id])
   laneId        String?
-  carrier       Carrier? @relation(fields: [carrierId], references: [id])
-  carrierId     String?  // Manual carrier assignment for non-lane shipments
-  loads         Load[]
+  carrierId     String?
   events        ShipmentEvent[]
-}
-
-model Carrier {
-  id           String   @id @default(uuid())
-  name         String
-  mcNumber     String?
-  dotNumber    String?
-  contactName  String?
-  contactEmail String?
-  contactPhone String?
-  address1     String?
-  address2     String?
-  city         String?
-  state        String?
-  postalCode   String?
-  country      String?
-  archived     Boolean  @default(false)
-  archivedAt   DateTime?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  vehicles     Vehicle[]
-  drivers      Driver[]
-  laneCarriers LaneCarrier[]
-  shipments    Shipment[]
-}
-
-model Vehicle {
-  id         String   @id @default(uuid())
-  carrier    Carrier  @relation(fields: [carrierId], references: [id])
-  carrierId  String
-  plate      String
-  type       String
-  capacityKg Int?
-  capacityM3 Int?
-  loads      Load[]
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-}
-
-model Driver {
-  id        String   @id @default(uuid())
-  carrier   Carrier  @relation(fields: [carrierId], references: [id])
-  carrierId String
-  name      String
-  phone     String?
-  email     String?
-  loads     Load[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-}
-
-model Load {
-  id         String   @id @default(uuid())
-  shipment   Shipment @relation(fields: [shipmentId], references: [id])
-  shipmentId String
-  vehicle    Vehicle? @relation(fields: [vehicleId], references: [id])
-  vehicleId  String?
-  driver     Driver?  @relation(fields: [driverId], references: [id])
-  driverId   String?
-  assignedAt DateTime?
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-}
-
-model Lane {
-  id            String   @id @default(uuid())
-  name          String   // Auto-generated: "Origin → Destination"
-  origin        Location @relation("LaneOrigin", fields: [originId], references: [id])
-  originId      String
-  destination   Location @relation("LaneDestination", fields: [destinationId], references: [id])
-  destinationId String
-  distance      Float?   // Optional distance in km
-  notes         String?
-  status        String   @default("active") // active/archived
-  archived      Boolean  @default(false)
-  archivedAt    DateTime?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
-  shipments     Shipment[]
-  customerLanes CustomerLane[]
-  laneCarriers  LaneCarrier[]
-  stops         LaneStop[]
-}
-
-model CustomerLane {
-  id         String   @id @default(uuid())
-  customer   Customer @relation(fields: [customerId], references: [id])
-  customerId String
-  lane       Lane     @relation(fields: [laneId], references: [id])
-  laneId     String
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-
-  @@unique([customerId, laneId])
-}
-
-model LaneCarrier {
-  id           String   @id @default(uuid())
-  lane         Lane     @relation(fields: [laneId], references: [id])
-  laneId       String
-  carrier      Carrier  @relation(fields: [carrierId], references: [id])
-  carrierId    String
-  price        Float?   // Price per shipment or per km
-  currency     String   @default("USD")
-  serviceLevel String?  // e.g., "Standard", "Express", "Economy"
-  notes        String?
-  assigned     Boolean  @default(false) // True if this carrier is assigned to the lane
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-
-  @@unique([laneId, carrierId])
-}
-
-model LaneStop {
-  id         String   @id @default(uuid())
-  lane       Lane     @relation(fields: [laneId], references: [id], onDelete: Cascade)
-  laneId     String
-  location   Location @relation(fields: [locationId], references: [id])
-  locationId String
-  order      Int      // Order of the stop in the lane (1, 2, 3, etc.)
-  notes      String?  // Optional notes for this specific stop
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-
-  @@unique([laneId, order])
-  @@unique([laneId, locationId])
 }
 
 model ShipmentEvent {


### PR DESCRIPTION
- #20: peekJobs now delegates to non-destructive peekJobsDirect instead
  of using fetch() which consumed and lost queued jobs
- #21: Slim webhook-service Prisma schema to only the 2 models it
  actually uses (Shipment, ShipmentEvent) instead of 13 drifted models
- #22: Add customer validation to LTL consolidation billing so orders
  from different customers cannot be mixed on the same shipment
- #24: Add Zod enum validation for order status field on update
  (pending, validated, location_error, converted, cancelled, archived)
- #25: Wrap stop status + order delivery updates in a Prisma transaction
  for atomicity; cargo reconciliation runs after commit as side effect
- #26: Add documentation comments to shared Vehicle type clarifying
  capacityKg/capacityM3 are whole integers matching the Prisma Int type
- #27: Add Zod schema validation for delivery status, delivery method,
  and exception type endpoints instead of accepting arbitrary strings

https://claude.ai/code/session_01R6KTja3FWA2LMPuqC1kywv