### PR TITLE
Fix invoice date test to use dynamic date instead of hardcoded value

### DIFF
--- a/backend/src/__tests__/commands/InvoiceCommands.test.ts
+++ b/backend/src/__tests__/commands/InvoiceCommands.test.ts
@@ -17,8 +17,10 @@ const mockCharge = {
   status: 'approved', freightClass: null,
 };
 
+const todayStr = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+
 const mockInvoice = {
-  id: 'inv-1', orgId: 'test-org', invoiceNumber: 'INV-20260412-0001',
+  id: 'inv-1', orgId: 'test-org', invoiceNumber: `INV-${todayStr}-0001`,
   customerId: 'cust-1', status: 'draft',
   subtotalCents: 150000, taxCents: 0, totalCents: 150000,
   paidCents: 0, balanceCents: 150000, currency: 'USD',
@@ -74,7 +76,7 @@ describe('Invoice Command Handlers', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(result.data?.invoiceNumber).toBe('INV-20260412-0001');
+      expect(result.data?.invoiceNumber).toBe(`INV-${todayStr}-0001`);
       expect(result.events).toHaveLength(1);
       expect(result.events[0].type).toBe(EVENT_TYPES.INVOICE_CREATED);
       expect(result.events[0].payload).toEqual(

--- a/backend/src/commands/invoices/CreateInvoiceCommand.ts
+++ b/backend/src/commands/invoices/CreateInvoiceCommand.ts
@@ -47,7 +47,7 @@ export class CreateInvoiceCommandHandler extends BaseCommandHandler<CreateInvoic
       throw new Error('No approved revenue charges found for the selected shipments');
     }
 
-    const subtotalCents = charges.reduce((sum, c) => sum + c.amountCents, 0);
+    const subtotalCents = charges.reduce((sum: number, c: any) => sum + c.amountCents, 0);
     const totalCents = subtotalCents;
     const currency = charges[0].currency;
 
@@ -87,7 +87,7 @@ export class CreateInvoiceCommandHandler extends BaseCommandHandler<CreateInvoic
         internalNotes: payload.internalNotes,
         createdBy: command.actorId,
         lineItems: {
-          create: charges.map(charge => ({
+          create: charges.map((charge: any) => ({
             shipmentId: charge.shipmentId,
             orderId: charge.orderId,
             chargeId: charge.id,
@@ -105,12 +105,12 @@ export class CreateInvoiceCommandHandler extends BaseCommandHandler<CreateInvoic
 
     // Mark charges as invoiced
     await tx.charge.updateMany({
-      where: { id: { in: charges.map(c => c.id) } },
+      where: { id: { in: charges.map((c: any) => c.id) } },
       data: { status: 'invoiced' },
     });
 
     // Update shipment billing status
-    const shipmentIds = [...new Set(charges.map(c => c.shipmentId).filter(Boolean) as string[])];
+    const shipmentIds = [...new Set(charges.map((c: any) => c.shipmentId).filter(Boolean) as string[])];
     await tx.shipmentFinancialSummary.updateMany({
       where: { shipmentId: { in: shipmentIds } },
       data: { billingStatus: 'invoiced' },

--- a/backend/src/commands/invoices/RecordPaymentCommand.ts
+++ b/backend/src/commands/invoices/RecordPaymentCommand.ts
@@ -107,7 +107,7 @@ export class RecordPaymentCommandHandler extends BaseCommandHandler<RecordPaymen
         where: { invoiceId: invoice.id },
         select: { shipmentId: true },
       });
-      const shipmentIds = [...new Set(lineItems.map(l => l.shipmentId).filter(Boolean) as string[])];
+      const shipmentIds = [...new Set(lineItems.map((l: any) => l.shipmentId).filter(Boolean) as string[])];
       if (shipmentIds.length > 0) {
         await tx.shipmentFinancialSummary.updateMany({
           where: { shipmentId: { in: shipmentIds } },

--- a/backend/src/commands/invoices/VoidInvoiceCommand.ts
+++ b/backend/src/commands/invoices/VoidInvoiceCommand.ts
@@ -39,7 +39,7 @@ export class VoidInvoiceCommandHandler extends BaseCommandHandler<VoidInvoicePay
 
     // Revert charges back to approved status
     const chargeIds = invoice.lineItems
-      .map(li => li.chargeId)
+      .map((li: any) => li.chargeId)
       .filter(Boolean) as string[];
 
     if (chargeIds.length > 0) {
@@ -50,7 +50,7 @@ export class VoidInvoiceCommandHandler extends BaseCommandHandler<VoidInvoicePay
     }
 
     // Revert shipment billing status to ready_to_invoice
-    const shipmentIds = [...new Set(invoice.lineItems.map(li => li.shipmentId).filter(Boolean) as string[])];
+    const shipmentIds = [...new Set(invoice.lineItems.map((li: any) => li.shipmentId).filter(Boolean) as string[])];
     if (shipmentIds.length > 0) {
       await tx.shipmentFinancialSummary.updateMany({
         where: { shipmentId: { in: shipmentIds } },


### PR DESCRIPTION
The test asserted invoice number INV-20260412-0001 but the command
generates numbers using the current date, so it fails on any other day.
Use a dynamic date string computed at test time. Also fix implicit any
type errors in invoice command handlers.

https://claude.ai/code/session_01D78TuQqUg4ryUHFUHfznDZ