### PR TITLE
Add proper time-series axes and period filtering to telemetry charts

### DIFF
--- a/backend/src/routes/telemetry.ts
+++ b/backend/src/routes/telemetry.ts
@@ -4,16 +4,50 @@ export default async function telemetryRoutes(server: FastifyInstance) {
   const prisma = server.prisma;
 
   // GET /api/v1/shipments/:id/telemetry — Sensor time-series for a shipment
-  server.get('/api/v1/shipments/:id/telemetry', async (req, reply) => {
+  server.get('/api/v1/shipments/:id/telemetry', {
+    schema: {
+      tags: ['Telemetry'],
+      summary: 'Get sensor time-series readings for a shipment',
+      params: {
+        type: 'object',
+        properties: { id: { type: 'string', format: 'uuid' } },
+        required: ['id'],
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          since: { type: 'string', format: 'date-time', description: 'Only return readings at or after this time' },
+          until: { type: 'string', format: 'date-time', description: 'Only return readings at or before this time' },
+          limit: { type: 'string', description: 'Max readings to return (default 500, max 2000)' },
+        },
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            data: { type: ['object', 'null'] },
+            error: { type: ['string', 'null'] },
+          },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const { id } = req.params as { id: string };
-    const query = req.query as { since?: string; limit?: string };
+    const query = req.query as { since?: string; until?: string; limit?: string };
     const limit = Math.min(parseInt(query.limit || '500'), 2000);
 
     try {
       const readings = await prisma.sensorReading.findMany({
         where: {
           shipmentId: id,
-          ...(query.since ? { eventTime: { gte: new Date(query.since) } } : {}),
+          ...(query.since || query.until
+            ? {
+                eventTime: {
+                  ...(query.since ? { gte: new Date(query.since) } : {}),
+                  ...(query.until ? { lte: new Date(query.until) } : {}),
+                },
+              }
+            : {}),
         },
         orderBy: { eventTime: 'asc' },
         take: limit,
@@ -46,16 +80,50 @@ export default async function telemetryRoutes(server: FastifyInstance) {
   });
 
   // GET /api/v1/orders/:id/telemetry — Sensor time-series for an order
-  server.get('/api/v1/orders/:id/telemetry', async (req, reply) => {
+  server.get('/api/v1/orders/:id/telemetry', {
+    schema: {
+      tags: ['Telemetry'],
+      summary: 'Get sensor time-series readings for an order',
+      params: {
+        type: 'object',
+        properties: { id: { type: 'string', format: 'uuid' } },
+        required: ['id'],
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          since: { type: 'string', format: 'date-time', description: 'Only return readings at or after this time' },
+          until: { type: 'string', format: 'date-time', description: 'Only return readings at or before this time' },
+          limit: { type: 'string', description: 'Max readings to return (default 500, max 2000)' },
+        },
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            data: { type: ['object', 'null'] },
+            error: { type: ['string', 'null'] },
+          },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const { id } = req.params as { id: string };
-    const query = req.query as { since?: string; limit?: string };
+    const query = req.query as { since?: string; until?: string; limit?: string };
     const limit = Math.min(parseInt(query.limit || '500'), 2000);
 
     try {
       const readings = await prisma.sensorReading.findMany({
         where: {
           orderId: id,
-          ...(query.since ? { eventTime: { gte: new Date(query.since) } } : {}),
+          ...(query.since || query.until
+            ? {
+                eventTime: {
+                  ...(query.since ? { gte: new Date(query.since) } : {}),
+                  ...(query.until ? { lte: new Date(query.until) } : {}),
+                },
+              }
+            : {}),
         },
         orderBy: { eventTime: 'asc' },
         take: limit,

--- a/frontend/src/vnext-design/TelemetryChart.tsx
+++ b/frontend/src/vnext-design/TelemetryChart.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { Thermometer } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+// ─── Time-series chart ──────────────────────────────────────────────────
+// Renders sensor readings as a proper X/Y line chart: X = time (actual
+// elapsed time between readings, not reading index), Y = value. Includes
+// axis tick labels on both axes and gridlines so the mapping is legible.
+
+export interface TimeSeriesPoint {
+  t: number; // epoch ms
+  v: number;
+  alert?: boolean;
+}
+
+export function readingsToSeries(readings: any[], field: string): TimeSeriesPoint[] {
+  return readings
+    .filter(r => r[field] != null && r.eventTime)
+    .map(r => ({ t: new Date(r.eventTime).getTime(), v: r[field], alert: !!r.isAlert }))
+    .sort((a, b) => a.t - b.t);
+}
+
+function formatTick(t: number, spanMs: number): string {
+  const d = new Date(t);
+  if (spanMs <= 48 * 60 * 60 * 1000) {
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric' }) +
+    ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export function TimeSeriesChart({
+  points,
+  unit = '',
+  lineClassName = 'stroke-primary',
+  pointClassName = 'fill-primary',
+  band,
+}: {
+  points: TimeSeriesPoint[];
+  unit?: string;
+  lineClassName?: string;
+  pointClassName?: string;
+  band?: { min: number | null; max: number | null } | null;
+}) {
+  if (points.length < 2) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
+        <Thermometer className="h-8 w-8" />
+        <h3 className="text-sm font-medium">Not enough data in this period</h3>
+      </div>
+    );
+  }
+
+  const w = 640, h = 220, padL = 48, padR = 16, padT = 16, padB = 30;
+  const plotW = w - padL - padR;
+  const plotH = h - padT - padB;
+
+  const minTime = points[0].t;
+  const maxTime = points[points.length - 1].t;
+  const timeSpan = maxTime - minTime || 1;
+
+  let minV = Math.min(...points.map(p => p.v));
+  let maxV = Math.max(...points.map(p => p.v));
+  if (band?.min != null) minV = Math.min(minV, band.min);
+  if (band?.max != null) maxV = Math.max(maxV, band.max);
+  const rawSpan = maxV - minV || 1;
+  const vPad = rawSpan * 0.15;
+  minV -= vPad;
+  maxV += vPad;
+  const valueSpan = maxV - minV || 1;
+
+  const xFor = (t: number) => padL + ((t - minTime) / timeSpan) * plotW;
+  const yFor = (v: number) => padT + (1 - (v - minV) / valueSpan) * plotH;
+
+  const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${xFor(p.t).toFixed(1)},${yFor(p.v).toFixed(1)}`).join(' ');
+
+  const xTickCount = 5;
+  const xTicks = Array.from({ length: xTickCount }, (_, i) => minTime + (timeSpan * i) / (xTickCount - 1));
+
+  const yTickCount = 4;
+  const yTicks = Array.from({ length: yTickCount }, (_, i) => minV + (valueSpan * i) / (yTickCount - 1));
+
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} className="h-auto w-full">
+      {band?.min != null && band?.max != null && (
+        <rect
+          x={padL}
+          y={yFor(band.max)}
+          width={plotW}
+          height={Math.max(0, yFor(band.min) - yFor(band.max))}
+          className="fill-success/10"
+        />
+      )}
+
+      {yTicks.map((v, i) => (
+        <g key={`y-${i}`}>
+          <line x1={padL} y1={yFor(v)} x2={w - padR} y2={yFor(v)} className="stroke-border" strokeDasharray="2,3" strokeWidth="1" />
+          <text x={padL - 6} y={yFor(v) + 3} textAnchor="end" className="fill-muted-foreground text-[10px]">
+            {v.toFixed(1)}{unit}
+          </text>
+        </g>
+      ))}
+
+      {xTicks.map((t, i) => (
+        <text key={`x-${i}`} x={xFor(t)} y={h - padB + 16} textAnchor="middle" className="fill-muted-foreground text-[10px]">
+          {formatTick(t, timeSpan)}
+        </text>
+      ))}
+
+      <line x1={padL} y1={padT} x2={padL} y2={h - padB} className="stroke-border" strokeWidth="1" />
+      <line x1={padL} y1={h - padB} x2={w - padR} y2={h - padB} className="stroke-border" strokeWidth="1" />
+
+      <path d={linePath} fill="none" className={lineClassName} strokeWidth="2" />
+
+      {points.map((p, i) => (
+        <circle
+          key={i}
+          cx={xFor(p.t)}
+          cy={yFor(p.v)}
+          r={p.alert ? 5 : 2.5}
+          className={p.alert ? 'fill-destructive' : pointClassName}
+        >
+          <title>{`${new Date(p.t).toLocaleString()}: ${p.v}${unit}${p.alert ? ' (alert)' : ''}`}</title>
+        </circle>
+      ))}
+    </svg>
+  );
+}
+
+// ─── Period filter ───────────────────────────────────────────────────────
+// Quick presets plus a custom from/to range, all expressed as ISO
+// since/until bounds the caller sends to the telemetry API.
+
+export type TelemetryPeriodKey = '24h' | '3d' | '7d' | '30d' | 'all' | 'custom';
+
+export const TELEMETRY_PERIODS: { key: TelemetryPeriodKey; label: string; hours?: number }[] = [
+  { key: '24h', label: '24h', hours: 24 },
+  { key: '3d', label: '3 days', hours: 72 },
+  { key: '7d', label: '7 days', hours: 168 },
+  { key: '30d', label: '30 days', hours: 720 },
+  { key: 'all', label: 'All time' },
+];
+
+export function computeTelemetryRange(
+  period: TelemetryPeriodKey,
+  customFrom: string,
+  customTo: string
+): { since: string | null; until: string | null } {
+  if (period === 'all') return { since: null, until: null };
+  if (period === 'custom') {
+    return {
+      since: customFrom ? new Date(customFrom).toISOString() : null,
+      until: customTo ? new Date(customTo).toISOString() : null,
+    };
+  }
+  const hours = TELEMETRY_PERIODS.find(p => p.key === period)?.hours ?? 168;
+  return { since: new Date(Date.now() - hours * 60 * 60 * 1000).toISOString(), until: null };
+}
+
+export function TelemetryPeriodFilter({
+  period,
+  onPeriodChange,
+  customFrom,
+  customTo,
+  onCustomFromChange,
+  onCustomToChange,
+}: {
+  period: TelemetryPeriodKey;
+  onPeriodChange: (p: TelemetryPeriodKey) => void;
+  customFrom: string;
+  customTo: string;
+  onCustomFromChange: (v: string) => void;
+  onCustomToChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {TELEMETRY_PERIODS.map(p => (
+        <Button
+          key={p.key}
+          size="sm"
+          variant={period === p.key ? 'default' : 'outline'}
+          onClick={() => onPeriodChange(p.key)}
+        >
+          {p.label}
+        </Button>
+      ))}
+      <Button
+        size="sm"
+        variant={period === 'custom' ? 'default' : 'outline'}
+        onClick={() => onPeriodChange('custom')}
+      >
+        Custom range
+      </Button>
+
+      {period === 'custom' && (
+        <div className="flex flex-wrap items-center gap-2 pl-1">
+          <label className="flex items-center gap-1 text-xs text-muted-foreground">
+            From
+            <input
+              type="datetime-local"
+              value={customFrom}
+              onChange={e => onCustomFromChange(e.target.value)}
+              className={cn('h-8 rounded-md border border-input bg-background px-2 text-xs')}
+            />
+          </label>
+          <label className="flex items-center gap-1 text-xs text-muted-foreground">
+            To
+            <input
+              type="datetime-local"
+              value={customTo}
+              onChange={e => onCustomToChange(e.target.value)}
+              className={cn('h-8 rounded-md border border-input bg-background px-2 text-xs')}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/vnext-design/VNextDeviceDetail.tsx
+++ b/frontend/src/vnext-design/VNextDeviceDetail.tsx
@@ -3,7 +3,6 @@ import { Link, useParams, useNavigate } from 'react-router-dom';
 import {
   ArrowLeft,
   Activity,
-  Thermometer,
   MapPin,
   Loader2,
   Link as LinkIcon,
@@ -12,6 +11,7 @@ import {
 
 import { API_URL } from '../api';
 import { getDeviceImageUrl } from './deviceImages';
+import { TimeSeriesChart, readingsToSeries } from './TelemetryChart';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -30,12 +30,14 @@ interface SensorReading {
   temperature: number | null;
   humidity: number | null;
   batteryLevel: number | null;
-  light: number | null;
-  impact: number | null;
+  lightLevel: number | null;
+  impactG: number | null;
+  tempMin: number | null;
+  tempMax: number | null;
   lat: number | null;
   lng: number | null;
   isAlert: boolean;
-  recordedAt: string;
+  eventTime: string;
 }
 
 interface DeviceEvent {
@@ -87,50 +89,6 @@ function relativeTime(dateStr: string | null): string {
   const hours = Math.floor(mins / 60);
   if (hours < 24) return `${hours}h ago`;
   return new Date(dateStr).toLocaleDateString();
-}
-
-function TempChart({ readings }: { readings: SensorReading[] }) {
-  const temps = readings.filter(r => r.temperature != null);
-  if (temps.length < 2) {
-    return (
-      <div className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
-        <Thermometer className="h-8 w-8" />
-        <h3 className="text-sm font-medium">Not enough data</h3>
-      </div>
-    );
-  }
-
-  const w = 600, h = 200, pad = 40;
-  const minT = Math.min(...temps.map(r => r.temperature!));
-  const maxT = Math.max(...temps.map(r => r.temperature!));
-  const range = maxT - minT || 1;
-
-  const points = temps.map((r, i) => ({
-    x: pad + (i / (temps.length - 1)) * (w - pad * 2),
-    y: pad + (1 - (r.temperature! - minT) / range) * (h - pad * 2),
-    alert: r.isAlert,
-  }));
-
-  const line = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
-
-  return (
-    <svg viewBox={`0 0 ${w} ${h}`} className="h-auto w-full">
-      <text x={pad} y={pad - 10} className="fill-muted-foreground text-[11px]">{maxT.toFixed(1)}°</text>
-      <text x={pad} y={h - pad + 16} className="fill-muted-foreground text-[11px]">{minT.toFixed(1)}°</text>
-      <line x1={pad} y1={pad} x2={pad} y2={h - pad} className="stroke-border" strokeWidth="1" />
-      <line x1={pad} y1={h - pad} x2={w - pad} y2={h - pad} className="stroke-border" strokeWidth="1" />
-      <path d={line} fill="none" className="stroke-primary" strokeWidth="2" />
-      {points.map((p, i) => (
-        <circle
-          key={i}
-          cx={p.x}
-          cy={p.y}
-          r={p.alert ? 5 : 3}
-          className={p.alert ? 'fill-destructive' : 'fill-primary'}
-        />
-      ))}
-    </svg>
-  );
 }
 
 function categoryVariant(category: string): 'destructive' | 'warning' | 'info' | 'secondary' {
@@ -253,7 +211,16 @@ export default function VNextDeviceDetail() {
               <span className="text-sm text-muted-foreground">{readings.length} readings</span>
             </CardHeader>
             <CardContent>
-              <TempChart readings={readings} />
+              <TimeSeriesChart
+                points={readingsToSeries(readings, 'temperature')}
+                unit="°"
+                band={(() => {
+                  const t = [...readings].find(r => r.tempMin != null || r.tempMax != null);
+                  return t ? { min: t.tempMin ?? null, max: t.tempMax ?? null } : null;
+                })()}
+                lineClassName="stroke-primary"
+                pointClassName="fill-primary"
+              />
             </CardContent>
             <CardContent className="p-0">
               <Table>
@@ -272,12 +239,12 @@ export default function VNextDeviceDetail() {
                 <TableBody>
                   {readings.slice(0, 20).map(r => (
                     <TableRow key={r.id}>
-                      <TableCell className="text-sm">{new Date(r.recordedAt).toLocaleString()}</TableCell>
+                      <TableCell className="text-sm">{new Date(r.eventTime).toLocaleString()}</TableCell>
                       <TableCell>{r.temperature != null ? `${r.temperature}°` : '-'}</TableCell>
                       <TableCell>{r.humidity != null ? `${r.humidity}%` : '-'}</TableCell>
                       <TableCell>{r.batteryLevel != null ? `${r.batteryLevel}%` : '-'}</TableCell>
-                      <TableCell>{r.light != null ? r.light : '-'}</TableCell>
-                      <TableCell>{r.impact != null ? r.impact : '-'}</TableCell>
+                      <TableCell>{r.lightLevel != null ? r.lightLevel : '-'}</TableCell>
+                      <TableCell>{r.impactG != null ? r.impactG : '-'}</TableCell>
                       <TableCell className="text-xs">
                         {r.lat != null && r.lng != null ? `${r.lat.toFixed(4)}, ${r.lng.toFixed(4)}` : '-'}
                       </TableCell>

--- a/frontend/src/vnext-design/VNextShipmentDetail.tsx
+++ b/frontend/src/vnext-design/VNextShipmentDetail.tsx
@@ -91,6 +91,13 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
 import { getDeviceImageUrl } from './deviceImages';
 import { keepMapSized } from '../lib/leafletMap';
 import {
+  TimeSeriesChart,
+  TelemetryPeriodFilter,
+  readingsToSeries,
+  computeTelemetryRange,
+  TelemetryPeriodKey,
+} from './TelemetryChart';
+import {
   SHIPMENT_STATUS_LABELS,
   allowedTransitions,
   canTransition,
@@ -118,51 +125,6 @@ const COLOR_SUCCESS = '#22c55e';
 const COLOR_WARNING = '#eab308';
 const COLOR_DESTRUCTIVE = '#ef4444';
 const COLOR_MUTED = '#94a3b8';
-
-// ─── Temperature Chart ──────────────────────────────────────────────────
-function ShipmentTempChart({ readings }: { readings: any[] }) {
-  const temps = readings.filter(r => r.temperature != null);
-  if (temps.length < 2) {
-    return (
-      <div className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
-        <Thermometer className="h-8 w-8" />
-        <h3 className="text-base font-medium">Not enough data</h3>
-      </div>
-    );
-  }
-
-  const w = 600, h = 200, pad = 40;
-  const minT = Math.min(...temps.map(r => r.temperature));
-  const maxT = Math.max(...temps.map(r => r.temperature));
-  const range = maxT - minT || 1;
-
-  const points = temps.map((r: any, i: number) => ({
-    x: pad + (i / (temps.length - 1)) * (w - pad * 2),
-    y: pad + (1 - (r.temperature - minT) / range) * (h - pad * 2),
-    alert: r.isAlert,
-  }));
-
-  const line = points.map((p: any, i: number) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
-
-  return (
-    <svg viewBox={`0 0 ${w} ${h}`} className="h-auto w-full">
-      <text x={pad} y={pad - 10} fill="currentColor" className="fill-muted-foreground text-[11px]">{maxT.toFixed(1)}°</text>
-      <text x={pad} y={h - pad + 16} fill="currentColor" className="fill-muted-foreground text-[11px]">{minT.toFixed(1)}°</text>
-      <line x1={pad} y1={pad} x2={pad} y2={h - pad} className="stroke-border" strokeWidth="1" />
-      <line x1={pad} y1={h - pad} x2={w - pad} y2={h - pad} className="stroke-border" strokeWidth="1" />
-      <path d={line} fill="none" className="stroke-primary" strokeWidth="2" />
-      {points.map((p: any, i: number) => (
-        <circle
-          key={i}
-          cx={p.x}
-          cy={p.y}
-          r={p.alert ? 5 : 3}
-          className={p.alert ? 'fill-destructive' : 'fill-primary'}
-        />
-      ))}
-    </svg>
-  );
-}
 
 // ─── Financials Tab ─────────────────────────────────────────────────────
 function FinancialsTab({ shipmentId }: { shipmentId: string }) {
@@ -273,13 +235,21 @@ function TelemetryTab({ shipmentId }: { shipmentId: string }) {
   const [telemetry, setTelemetry] = useState<any>(null);
   const [tLoading, setTLoading] = useState(true);
   const [tError, setTError] = useState('');
+  const [period, setPeriod] = useState<TelemetryPeriodKey>('all');
+  const [customFrom, setCustomFrom] = useState('');
+  const [customTo, setCustomTo] = useState('');
+
+  const range = computeTelemetryRange(period, customFrom, customTo);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         setTLoading(true);
-        const res = await fetch(`${API_URL}/api/v1/shipments/${shipmentId}/telemetry`);
+        const params = new URLSearchParams({ limit: '2000' });
+        if (range.since) params.set('since', range.since);
+        if (range.until) params.set('until', range.until);
+        const res = await fetch(`${API_URL}/api/v1/shipments/${shipmentId}/telemetry?${params}`);
         if (!res.ok) throw new Error(`Failed to load telemetry (${res.status})`);
         const json = await res.json();
         if (json.error) throw new Error(json.error);
@@ -294,31 +264,39 @@ function TelemetryTab({ shipmentId }: { shipmentId: string }) {
       }
     })();
     return () => { cancelled = true; };
-  }, [shipmentId]);
+  }, [shipmentId, range.since, range.until]);
 
-  if (tLoading) {
-    return (
-      <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
-        <Loader2 className="h-6 w-6 animate-spin" />
-        <h3 className="text-base font-medium">Loading telemetry...</h3>
-      </div>
-    );
-  }
+  const periodFilter = (
+    <TelemetryPeriodFilter
+      period={period}
+      onPeriodChange={setPeriod}
+      customFrom={customFrom}
+      customTo={customTo}
+      onCustomFromChange={setCustomFrom}
+      onCustomToChange={setCustomTo}
+    />
+  );
 
   if (tError) {
     return (
-      <div className="flex items-center gap-3 rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
-        <XCircle className="h-5 w-5" />
-        {tError}
+      <div className="space-y-4">
+        {periodFilter}
+        <div className="flex items-center gap-3 rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+          <XCircle className="h-5 w-5" />
+          {tError}
+        </div>
       </div>
     );
   }
 
-  if (!telemetry) {
+  if (tLoading || !telemetry) {
     return (
-      <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
-        <Thermometer className="h-8 w-8" />
-        <h3 className="text-base font-medium">No telemetry data</h3>
+      <div className="space-y-4">
+        {periodFilter}
+        <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
+          <Loader2 className="h-6 w-6 animate-spin" />
+          <h3 className="text-base font-medium">Loading telemetry...</h3>
+        </div>
       </div>
     );
   }
@@ -341,8 +319,20 @@ function TelemetryTab({ shipmentId }: { shipmentId: string }) {
   });
   const trackerDevices = Array.from(deviceMap.values());
 
+  const tempSeries = readingsToSeries(readings, 'temperature');
+  const humiditySeries = readingsToSeries(readings, 'humidity');
+  const pressureSeries = readingsToSeries(readings, 'atmosphericPressure');
+  const batterySeries = readingsToSeries(readings, 'batteryLevel');
+
+  const thresholdReading = [...readings].reverse().find((r: any) => r.tempMin != null || r.tempMax != null);
+  const tempBand = thresholdReading
+    ? { min: thresholdReading.tempMin ?? null, max: thresholdReading.tempMax ?? null }
+    : null;
+
   return (
     <div className="space-y-6">
+      {periodFilter}
+
       {trackerDevices.length > 0 && (
         <Card>
           <CardHeader><CardTitle className="text-base">Tracking Devices</CardTitle></CardHeader>
@@ -405,12 +395,54 @@ function TelemetryTab({ shipmentId }: { shipmentId: string }) {
         </Card>
       </div>
 
-      <Card>
-        <CardHeader><CardTitle className="text-base">Temperature</CardTitle></CardHeader>
-        <CardContent>
-          <ShipmentTempChart readings={readings} />
-        </CardContent>
-      </Card>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader><CardTitle className="text-base">Temperature over time</CardTitle></CardHeader>
+          <CardContent>
+            <TimeSeriesChart
+              points={tempSeries}
+              unit="°"
+              band={tempBand}
+              lineClassName="stroke-primary"
+              pointClassName="fill-primary"
+            />
+            {tempBand && (tempBand.min != null || tempBand.max != null) && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Shaded band shows the acceptable range
+                {tempBand.min != null ? ` (${tempBand.min}°` : ' (up to'}
+                {tempBand.max != null ? ` to ${tempBand.max}°)` : ')'}.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {humiditySeries.length >= 2 && (
+          <Card>
+            <CardHeader><CardTitle className="text-base">Humidity over time</CardTitle></CardHeader>
+            <CardContent>
+              <TimeSeriesChart points={humiditySeries} unit="%" lineClassName="stroke-info" pointClassName="fill-info" />
+            </CardContent>
+          </Card>
+        )}
+
+        {pressureSeries.length >= 2 && (
+          <Card>
+            <CardHeader><CardTitle className="text-base">Atmospheric pressure over time</CardTitle></CardHeader>
+            <CardContent>
+              <TimeSeriesChart points={pressureSeries} unit=" hPa" lineClassName="stroke-warning" pointClassName="fill-warning" />
+            </CardContent>
+          </Card>
+        )}
+
+        {batterySeries.length >= 2 && (
+          <Card>
+            <CardHeader><CardTitle className="text-base">Battery over time</CardTitle></CardHeader>
+            <CardContent>
+              <TimeSeriesChart points={batterySeries} unit="%" lineClassName="stroke-success" pointClassName="fill-success" />
+            </CardContent>
+          </Card>
+        )}
+      </div>
 
       <Card>
         <CardHeader><CardTitle className="text-base">Recent Readings</CardTitle></CardHeader>


### PR DESCRIPTION
Shipment/device temperature charts plotted readings by index instead of
actual elapsed time, so the X axis had no time labels and unevenly spaced
readings looked evenly spaced. Replace with a shared TimeSeriesChart that
scales points by real timestamp, labels both axes, and shades the
acceptable temperature band. Add humidity/pressure/battery charts and a
period filter (quick presets + custom range) backed by a new `until` query
param on the telemetry endpoints.

Fixes #75

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Aj9EU7hbsnLgrhRKYuxHzG