### PR TITLE
Fix specialRequirements silently dropped on order create/update

### DIFF
--- a/backend/src/__tests__/commands/OrderCommands.test.ts
+++ b/backend/src/__tests__/commands/OrderCommands.test.ts
@@ -161,6 +161,36 @@ describe('Order Command Handlers', () => {
       }));
     });
 
+    it('persists specialRequirements to the create call', async () => {
+      mockTx.order.create.mockClear();
+      const { bus } = mockEventBus();
+      const handler = new CreateOrderCommandHandler(mockPrisma, bus);
+
+      await handler.execute(
+        createTestCommand(CREATE_ORDER, {
+          orderData: {
+            orgId: 'test-org',
+            orderNumber: 'ORD-REQ-1',
+            customerId: 'cust-1',
+            serviceLevel: 'FTL',
+            temperatureControl: 'refrigerated',
+            requiresHazmat: false,
+            specialRequirements: ['liftgate', 'inside_delivery'],
+          },
+          status: 'pending',
+        })
+      );
+
+      expect(mockTx.order.create).toHaveBeenCalledTimes(1);
+      const dataArg = mockTx.order.create.mock.calls[0][0].data;
+      expect(dataArg).toEqual(expect.objectContaining({
+        serviceLevel: 'FTL',
+        temperatureControl: 'refrigerated',
+        requiresHazmat: false,
+        specialRequirements: ['liftgate', 'inside_delivery'],
+      }));
+    });
+
     it('auto-generates N TrackableUnits when packingSummary is supplied', async () => {
       mockTx.order.create.mockClear();
       mockTx.packagingType.findUnique.mockResolvedValueOnce({ kind: 'pallet' });
@@ -314,6 +344,27 @@ describe('Order Command Handlers', () => {
       expect(result.success).toBe(true);
       expect(result.events.length).toBeGreaterThanOrEqual(1);
       expect(result.events[0].type).toBe(EVENT_TYPES.ORDER_UPDATED);
+    });
+
+    it('forwards specialRequirements through to the update call', async () => {
+      mockTx.order.update.mockClear();
+      const { bus } = mockEventBus();
+      const handler = new UpdateOrderCommandHandler(mockPrisma, bus);
+
+      const result = await handler.execute(
+        createTestCommand(UPDATE_ORDER, {
+          id: 'order-1',
+          data: { specialRequirements: ['tail_lift', 'appointment_required'] },
+        })
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockTx.order.update).toHaveBeenCalledTimes(1);
+      expect(mockTx.order.update.mock.calls[0][0].data).toEqual(
+        expect.objectContaining({
+          specialRequirements: ['tail_lift', 'appointment_required'],
+        })
+      );
     });
 
     it('emits ORDER_STATUS_CHANGED when status changes', async () => {

--- a/backend/src/commands/orders/CreateOrderCommand.ts
+++ b/backend/src/commands/orders/CreateOrderCommand.ts
@@ -179,6 +179,7 @@ export class CreateOrderCommandHandler extends BaseCommandHandler<CreateOrderPay
         serviceLevel: orderData.serviceLevel,
         temperatureControl: orderData.temperatureControl,
         requiresHazmat: orderData.requiresHazmat,
+        specialRequirements: orderData.specialRequirements,
         specialInstructions: orderData.specialInstructions,
         notes: orderData.notes,
         status,

--- a/backend/src/commands/orders/UpdateOrderCommand.ts
+++ b/backend/src/commands/orders/UpdateOrderCommand.ts
@@ -17,6 +17,7 @@ export interface UpdateOrderPayload {
     serviceLevel?: string;
     temperatureControl?: string;
     requiresHazmat?: boolean;
+    specialRequirements?: string[];
     specialInstructions?: string;
     notes?: string;
   };

--- a/backend/src/repositories/OrdersRepository.ts
+++ b/backend/src/repositories/OrdersRepository.ts
@@ -79,6 +79,8 @@ export interface CreateOrderDTO {
   serviceLevel?: string;
   temperatureControl?: string;
   requiresHazmat?: boolean;
+  /** Free-form requirement tags. Persisted to the Order.specialRequirements Json column. */
+  specialRequirements?: string[];
 
   // Trackable units (new preferred way)
   trackableUnits?: CreateTrackableUnitDTO[];

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -158,6 +158,7 @@ const updateOrderSchema = z.object({
   serviceLevel: z.string().optional(),
   temperatureControl: z.string().optional(),
   requiresHazmat: z.boolean().optional(),
+  specialRequirements: z.array(z.string()).optional(),
   specialInstructions: z.string().optional(),
   notes: z.string().optional()
 });


### PR DESCRIPTION
## Problem

`POST /api/v1/orders` accepts `specialRequirements` in its Zod schema (`routes/orders.ts:128`) and the Prisma `Order` model has the matching `Json?` column (`schema.prisma:720`) — but `CreateOrderCommand` never mapped the field into `tx.order.create`. Anything a client sent was discarded with no error. The generic update path had neither a route-schema entry nor a payload field for it.

## Fix

- `specialRequirements` added to `CreateOrderDTO` and the `CreateOrderCommand` create map
- Added to `UpdateOrderPayload` and `updateOrderSchema` so it can be edited
- Two command-handler tests covering create and update

## Deliberately not taken

Salvaged from the stale `claude/fix-incomplete-features-6gfCj` branch. The rest of that commit widened `updateOrderSchema` with `deliveryStatus`, `deliveredAt`, `exceptionType` and friends. That is **not** included: main now routes those through the dedicated `/delivery-status` and `/delivery-exception` endpoints backed by `IOrderDeliveryService`, and putting them on the generic update path would let callers bypass it and its event emission.

## Verification

- 1586/1586 backend tests pass
- `tsc --noEmit`: 22 errors, identical to the pre-existing count on main (none in touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)