### PR TITLE
Implement address geocoding in DistanceService

### DIFF
--- a/backend/src/__tests__/distanceService.simple.test.ts
+++ b/backend/src/__tests__/distanceService.simple.test.ts
@@ -106,3 +106,106 @@ describe('DistanceService - Simple Tests', () => {
     });
   });
 });
+
+describe('DistanceService - geocoding', () => {
+  const addrOnly = {
+    lat: null as number | null,
+    lng: null as number | null,
+    address1: '1234 Commerce Street',
+    address2: null,
+    city: 'Dallas',
+    state: 'Texas',
+    postalCode: '75201',
+    country: 'USA'
+  };
+  const withCoords = {
+    lat: 40.7128,
+    lng: -74.0060,
+    address1: '1000 6th Ave',
+    address2: null,
+    city: 'New York',
+    state: 'New York',
+    postalCode: '10018',
+    country: 'USA'
+  };
+
+  const originalKey = process.env.GOOGLE_MAPS_API_KEY;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.GOOGLE_MAPS_API_KEY;
+  });
+
+  afterAll(() => {
+    if (originalKey === undefined) delete process.env.GOOGLE_MAPS_API_KEY;
+    else process.env.GOOGLE_MAPS_API_KEY = originalKey;
+  });
+
+  it('skips geocoding entirely when both endpoints already have coordinates', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+
+    await DistanceService.getDistanceWithGeocoding(withCoords, withCoords);
+
+    // Only the distance lookup should fire, never a geocode call
+    const calledUrls = (global.fetch as jest.Mock).mock.calls.map((c) => String(c[0]));
+    expect(calledUrls.some((u) => u.includes('geocode') || u.includes('nominatim'))).toBe(false);
+  });
+
+  it('uses Google Geocoding when GOOGLE_MAPS_API_KEY is set', async () => {
+    process.env.GOOGLE_MAPS_API_KEY = 'test-key';
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (String(url).includes('maps/api/geocode')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            status: 'OK',
+            results: [{ geometry: { location: { lat: 32.7767, lng: -96.797 } } }]
+          })
+        });
+      }
+      return Promise.resolve({ ok: false, status: 500 });
+    });
+
+    const result = await DistanceService.getDistanceWithGeocoding(addrOnly, withCoords);
+
+    const calledUrls = (global.fetch as jest.Mock).mock.calls.map((c) => String(c[0]));
+    expect(calledUrls.some((u) => u.includes('maps/api/geocode'))).toBe(true);
+    expect(calledUrls.some((u) => u.includes('nominatim'))).toBe(false);
+    // Geocoding succeeded, so we get a real distance rather than the geocode failure
+    expect(result.error).not.toBe('Could not geocode one or both addresses');
+    expect(result.distance).toBeGreaterThan(0);
+  });
+
+  it('falls back to Nominatim when no API key is configured', async () => {
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (String(url).includes('nominatim')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ lat: '32.7767', lon: '-96.797' }])
+        });
+      }
+      return Promise.resolve({ ok: false, status: 500 });
+    });
+
+    const result = await DistanceService.getDistanceWithGeocoding(addrOnly, withCoords);
+
+    const calledUrls = (global.fetch as jest.Mock).mock.calls.map((c) => String(c[0]));
+    expect(calledUrls.some((u) => u.includes('nominatim'))).toBe(true);
+    expect(calledUrls.some((u) => u.includes('maps/api/geocode'))).toBe(false);
+    expect(result.distance).toBeGreaterThan(0);
+  });
+
+  it('returns a clear error when an address cannot be geocoded', async () => {
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (String(url).includes('nominatim')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: false, status: 500 });
+    });
+
+    const result = await DistanceService.getDistanceWithGeocoding(addrOnly, withCoords);
+
+    expect(result.distance).toBe(0);
+    expect(result.error).toBe('Could not geocode one or both addresses');
+  });
+});

--- a/backend/src/services/distanceService.ts
+++ b/backend/src/services/distanceService.ts
@@ -152,6 +152,95 @@ export class DistanceService {
     };
   }
 
+  private static readonly GOOGLE_GEOCODING_API_URL = 'https://maps.googleapis.com/maps/api/geocode/json';
+  private static readonly NOMINATIM_API_URL = 'https://nominatim.openstreetmap.org/search';
+
+  /**
+   * Geocode an address to lat/lng coordinates.
+   *
+   * Provider priority:
+   *   1. Google Geocoding API — if GOOGLE_MAPS_API_KEY env var is set
+   *   2. OpenStreetMap Nominatim — free fallback, no API key required
+   *
+   * Set GOOGLE_MAPS_API_KEY to use Google. Otherwise Nominatim is used automatically.
+   */
+  private static async geocodeAddress(location: Location): Promise<{ lat: number; lng: number } | null> {
+    // Try Google Geocoding first if API key is available
+    const googleKey = process.env.GOOGLE_MAPS_API_KEY;
+    if (googleKey) {
+      const result = await this.geocodeWithGoogle(location, googleKey);
+      if (result) return result;
+    }
+
+    // Fallback to Nominatim (free, no key required)
+    return this.geocodeWithNominatim(location);
+  }
+
+  /**
+   * Google Geocoding API — requires GOOGLE_MAPS_API_KEY.
+   * https://developers.google.com/maps/documentation/geocoding
+   */
+  private static async geocodeWithGoogle(location: Location, apiKey: string): Promise<{ lat: number; lng: number } | null> {
+    const address = [location.address1, location.city, location.state, location.postalCode, location.country]
+      .filter(Boolean)
+      .join(', ');
+
+    if (!address.trim()) return null;
+
+    try {
+      const params = new URLSearchParams({ address, key: apiKey });
+      const response = await fetch(`${this.GOOGLE_GEOCODING_API_URL}?${params}`);
+      if (!response.ok) {
+        console.warn('Google Geocoding API request failed:', response.status);
+        return null;
+      }
+
+      const data = await response.json();
+      if (data.status === 'OK' && data.results?.length > 0) {
+        const { lat, lng } = data.results[0].geometry.location;
+        return { lat, lng };
+      }
+      if (data.status !== 'ZERO_RESULTS') {
+        console.warn('Google Geocoding API returned:', data.status, data.error_message);
+      }
+    } catch (error) {
+      console.warn('Google Geocoding error:', error);
+    }
+
+    return null;
+  }
+
+  /**
+   * OpenStreetMap Nominatim — free geocoding, no API key required.
+   * Rate limit: 1 request/second per Nominatim usage policy.
+   * https://nominatim.org/release-docs/develop/api/Search/
+   */
+  private static async geocodeWithNominatim(location: Location): Promise<{ lat: number; lng: number } | null> {
+    const parts = [location.address1, location.city, location.state, location.postalCode, location.country]
+      .filter(Boolean)
+      .join(', ');
+
+    if (!parts.trim()) return null;
+
+    try {
+      const params = new URLSearchParams({ q: parts, format: 'json', limit: '1' });
+      const response = await fetch(`${this.NOMINATIM_API_URL}?${params}`, {
+        headers: { 'User-Agent': 'OpenTMS/0.1.0' },
+      });
+
+      if (!response.ok) return null;
+
+      const data = await response.json();
+      if (data.length > 0) {
+        return { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) };
+      }
+    } catch (error) {
+      console.warn('Nominatim geocoding error:', error);
+    }
+
+    return null;
+  }
+
   // Get distance with address geocoding (if coordinates are missing)
   static async getDistanceWithGeocoding(origin: Location, destination: Location): Promise<DistanceResult> {
     // If we have coordinates, use them directly
@@ -159,11 +248,27 @@ export class DistanceService {
       return this.getDistance(origin, destination);
     }
 
-    // TODO: Implement geocoding service to get coordinates from addresses
-    // For now, return error if coordinates are missing
-    return {
-      distance: 0,
-      error: 'Coordinates required for distance calculation'
-    };
+    // Geocode whichever endpoint is missing coordinates
+    let originCoords = origin.lat && origin.lng ? { lat: origin.lat, lng: origin.lng } : null;
+    let destCoords = destination.lat && destination.lng ? { lat: destination.lat, lng: destination.lng } : null;
+
+    if (!originCoords) {
+      originCoords = await this.geocodeAddress(origin);
+    }
+    if (!destCoords) {
+      destCoords = await this.geocodeAddress(destination);
+    }
+
+    if (!originCoords || !destCoords) {
+      return {
+        distance: 0,
+        error: 'Could not geocode one or both addresses'
+      };
+    }
+
+    return this.getDistance(
+      { ...origin, lat: originCoords.lat, lng: originCoords.lng },
+      { ...destination, lat: destCoords.lat, lng: destCoords.lng }
+    );
   }
 }


### PR DESCRIPTION
## Problem

`DistanceService.getDistanceWithGeocoding()` was a stub — a `TODO` comment and an unconditional `'Coordinates required for distance calculation'` error, so it could never do the one thing its name promises.

## Fix

Implements `geocodeAddress()` using the same provider priority the distance lookup already follows:

1. **Google Geocoding API** when `GOOGLE_MAPS_API_KEY` is set
2. **OpenStreetMap Nominatim** as a free, keyless fallback

`getDistanceWithGeocoding()` now geocodes whichever endpoint lacks coordinates, and returns `'Could not geocode one or both addresses'` only when that genuinely fails.

## Scope note

This method currently has **no callers** in the codebase, so nothing changes behaviourally today. It is fixed so the capability is real when a caller needs it, rather than a stub that silently fails.

## Verification

- 4 new tests: Google path, Nominatim fallback, geocode failure, and the no-op path when coordinates are already present
- 1588/1588 backend tests pass
- `tsc --noEmit`: 22 errors, identical to the pre-existing count on main

Cherry-picked from `claude/plan-roadmap-features-mEoPs` (`a153119`) and resolved against main, which had diverged 302 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)