### PR TITLE
Docs: add operating workflows spec and executable test runbook

### DIFF
--- a/docs/workflows/01-ACTORS-ROLES-SCOPE.md
+++ b/docs/workflows/01-ACTORS-ROLES-SCOPE.md
@@ -1,0 +1,231 @@
+# 01 - Actors, Roles, Scope & Reporting
+
+This defines **who acts on the platform**, what each actor is allowed to do, the **explicit scope boundary**
+(what Open TMS does and deliberately does not do), and the **reporting suite** the operation needs.
+
+---
+
+## 1. Actors
+
+There are three classes of actor: **internal users** (your staff, authenticated with the internal JWT),
+**external portal users** (customers and carriers, each with their own auth model), and the
+**system / automation** layer (event-driven workers that act with no human in the loop).
+
+### 1.1 Internal users (roles)
+
+Internal roles are defined in `backend/src/auth/permissions.ts`. A user has one or more roles; permissions are
+`resource:action` strings (`*` = wildcard). Assign roles with `POST /api/v1/roles/:roleId/users/:userId`.
+
+| Role | Intended actor | Can do | Cannot do |
+|------|---------------|--------|-----------|
+| **admin** | Platform owner / IT | Everything (`*`) | - |
+| **dispatcher** | Operations / dispatch | Full shipments, orders, issues, tenders, documents, load board; **read** carriers/customers/lanes/locations; read quotes/charges/invoices | Change settings, manage users, write financials |
+| **broker_admin** | Brokerage owner/manager | Everything operational **and** financial **and** EDI/integrations/automation/users/settings (everything except role *creation*) | Edit system role definitions |
+| **broker_agent** | Brokerage sales/ops rep | Quote customers, manage load board, assign carriers, view margin, run credit checks, generate rate confirmations; write shipments/orders/issues/tenders; full quotes | Manage users or settings, write invoices/charges |
+| **finance** | AR/AP / accounts | Full quotes, charges, invoices, carrier invoices, financial reports; run credit checks; generate documents | Write operational shipment/order data, manage users/settings |
+| **warehouse** | Warehouse / dock operator | Read+write shipments at their location, read orders, read+write devices, read documents | Anything financial, carriers, customers, settings |
+| **readonly** | Management / auditors | Read everything operational and financial | Any write |
+
+**Who does the initial setup?** The **admin** (or **broker_admin**) created during bootstrap. Settings,
+org-type, users, and global config are admin-only.
+
+### 1.2 External portal users
+
+Two separate auth models exist (neither is the internal `User`). **There is no self-registration for either**
+- an internal admin provisions every external login.
+
+| Portal | Auth model | Roles | Provisioned by | Default seed password |
+|--------|-----------|-------|----------------|----------------------|
+| **Customer Portal** (`/customer-portal`) | `CustomerUser` | `viewer` (read-only), `admin` (read+write) | Internal admin, after the Customer exists: `POST /api/v1/customers/:customerId/users` | `Portal123!` |
+| **Carrier Portal** (`/carrier-portal`) | `CarrierUser` | `dispatcher`, `admin` | Internal admin, after the Carrier exists: `POST /api/v1/carriers/:carrierId/users` | `Carrier123!` |
+
+Both portals enforce password strength (8+ chars, upper/lower/number) and account lockout (5 fails → 15 min).
+
+#### Customer portal user - tasks they perform
+
+| Task | Endpoint | Status |
+|------|----------|--------|
+| Log in / profile / change password | `POST /api/v1/customer-portal/login`, `/profile`, `/change-password` | ✅ |
+| **Submit an order** (self-service order entry) | `POST /api/v1/customer-portal/orders` | ✅ |
+| View orders & order detail | `GET /api/v1/customer-portal/orders[/:id]` | ✅ |
+| Track shipments (status, stops, recent events) | `GET /api/v1/customer-portal/shipments[/:id]` | ✅ |
+| Download documents (BOL, label, customs, POD, rate conf) | `GET /api/v1/customer-portal/documents[/:id/download]` | ✅ |
+| View invoices & **raise a dispute** (→ creates a financial query) | `GET .../invoices[/:id]`, `POST .../invoices/:id/dispute` | ✅ |
+| **Request a return / RMA**, track it, download return label | `POST /api/v1/customer-portal/rmas`, `/:id`, `/:id/return-label` | ✅ |
+| Developer area: API keys, webhooks (HMAC-signed), EDI partner view, EDI log | `/api/v1/customer-portal/developer/*` | ✅ |
+| Edit an order after submission | - | ❌ Gap |
+| Pay an invoice online | - | 🔌 Out of scope (no payment processing) |
+| Configure their own EDI settings | - | 🟡 Read-only (admin-managed) |
+
+#### Carrier portal user - tasks they perform
+
+| Task | Endpoint | Status |
+|------|----------|--------|
+| Log in / profile / change password | `POST /api/v1/carrier-portal/login`, `/profile`, `/change-password` | ✅ |
+| View active tender offers | `GET /api/v1/carrier-portal/tenders[/:id]` | ✅ |
+| **Submit a bid** (rate, transit days, equipment, notes) | `POST /api/v1/carrier-portal/tenders/:id/bid` | ✅ |
+| Decline a tender | `POST /api/v1/carrier-portal/tenders/:id/decline` | ✅ |
+| Bid history & tender history (win/loss) | `GET /api/v1/carrier-portal/bids`, `/history` | ✅ |
+| Accept / view an *awarded* load with stop details | - | ❌ Gap (bidding only; no load-acceptance view) |
+| Submit POD / status updates from the field | - | ❌ Gap (no driver app) |
+| Book a dock appointment | - | ❌ Gap |
+| Self-register / upload onboarding docs | - | ❌ Gap (admin-only onboarding) |
+
+### 1.3 Customer API (programmatic, not a human)
+
+Customers (or their systems) can integrate via an API key scoped to a Customer (`x-api-key` header). See
+`docs/CUSTOMER_API_GUIDE.md`.
+
+| Task | Endpoint |
+|------|----------|
+| Create an order (optionally `autoAssign`) | `POST /api/v1/customer-api/orders` |
+| List / get / status-check orders | `GET /api/v1/customer-api/orders[/:id][/status]` |
+| Create / list / get returns | `POST /api/v1/customer-api/rmas`, `GET .../rmas[/:id]` |
+
+### 1.4 System / automation actors
+
+These act with no human in the loop and are first-class participants in the workflows:
+
+| Actor | What it does | Trigger |
+|-------|-------------|---------|
+| Projection workers | Maintain denormalized read models (Shipment, Order, Carrier, Customer, Lane, Issue, Invoice) | Every domain event, polled ~0.5s |
+| Auto-tender | Broadcasts a tender to all active carriers for laneless shipments | `shipment.created` (if org setting enabled) |
+| ETA monitor (cron) | Traffic-aware ETA checks, delay severity, route-deviation alerts | pg-boss cron, adaptive polling |
+| Carrier tracking poll | Pulls FedEx/UPS/DHL status, bridges to shipment lifecycle | Cron, every 5 min |
+| SLA breach detection | Detects breaches, auto-creates issues | Hybrid event + cron |
+| AI triage agent | Triages exceptions/breaches into issues (create/escalate/contact driver) | Exception events (if LLM key set) |
+| Automation rule engine | Deterministic when/given/then rules promoted from agent decisions | Matching events |
+| Billing trigger | Marks shipment ready-to-invoice, optionally auto-drafts invoice | `shipment.delivered` |
+
+---
+
+## 2. RACI by operating model
+
+Who is **R**esponsible for each major activity. (A = the org owner/admin is Accountable in all models.)
+
+| Activity | [Shipper] | [Broker] | [3PL] |
+|----------|-----------|----------|-------|
+| Initial setup & org config | Logistics/IT admin | Brokerage admin | 3PL platform admin |
+| Create **Customers** | Ops (their receivers/BUs) | Sales / broker_agent (their shipper clients) | Onboarding team (each client) |
+| Provision customer portal logins | Ops admin | Broker agent / admin | 3PL onboarding |
+| Create **Locations** | Ops (own DCs + customer sites) | Ops (pickup/delivery sites) | Ops (client + network sites) |
+| Onboard **Carriers** (+ validation) | Procurement | Carrier sales / broker_admin | Carrier management team |
+| Provision carrier portal logins | Procurement | Carrier sales | Carrier management |
+| Create **Lanes** + rates | Procurement / ops | Pricing / broker_agent | Network/ops team |
+| Create **Orders** | Ops, EDI 850, or customer API | Customer (portal/API), agent, or EDI | Client (portal/API/EDI) or ops |
+| Book / cover freight (tender or assign) | Dispatcher | broker_agent (load board) | Dispatcher / control tower |
+| Quote a price to the customer | n/a (internal cost only) | broker_agent (quote → margin) | Account manager (quote) |
+| Invoice the customer (AR) | n/a (no customer billing) | finance | finance |
+| Pay / audit the carrier (AP) | finance | finance | finance |
+| Monitor exceptions / SLAs | Dispatcher + triage | Ops + triage | Control tower + triage |
+
+The clearest divergence: **[Shipper]** has *no customer-AR side* (they are the shipper; "customers" are
+receivers), whereas **[Broker]** and **[3PL]** run the full quote → AR → margin loop on top of the AP loop.
+
+---
+
+## 3. Scope boundary
+
+### 3.1 In scope (the platform does this)
+
+Order & shipment lifecycle · trackable units & cargo scanning · order→shipment conversion (combine/split) ·
+lanes & multi-stop routes · carrier management with validation tiers · broadcast & waterfall tendering ·
+carrier & customer portals · GPS/IoT tracking & geofencing · ETA monitoring & route-deviation · cold-chain
+compliance (CFR 21 Part 11) · issue/triage centre with SLA management · charges, rating (incl. class-based
+LTL), quotes, customer invoicing (AR), carrier invoicing (AP) with three-way freight audit, financial queries
+& credit notes · EDI X12 (850/855/856/204/990/997/214/210/810/820/180/940/945) · returns/RMA · document
+generation (BOL, labels, customs, PODs, reports) · white-label theming · custom fields · AI triage &
+automation rules & skills.
+
+### 3.2 Out of scope - and why
+
+These are deliberate boundaries. Where money or another system of record is involved, Open TMS **records and
+hands off** rather than executing. Each is a candidate "integration point", not a build gap.
+
+| Out of scope | What the platform does instead | Belongs to |
+|--------------|--------------------------------|-----------|
+| **Payment execution / money movement** | Records invoices and payments; no card/ACH/wire processing | 🔌 Payment processor / bank |
+| **General ledger & accounting** | Exports CSV (invoice register, payment ledger, charge detail) | 🔌 QuickBooks / NetSuite / SAP / Xero |
+| **Tax calculation** | Stores `taxId`/VAT; no rate determination | 🔌 Avalara / tax engine |
+| **Full WMS (inventory, pick/pack, slotting, WCS)** | Has location ops, dock, trackable units; WMS v1/v2 is a separate track | 🔌 / 🟡 External WMS or WMS track |
+| **Multi-modal ocean / air / rail legs** | Road-only schema (TL/LTL) | ❌ Deferred |
+| **International customs / duty / denied-party screening** | Generates customs *documents* only | ❌ Not built |
+| **Route / load optimisation (TSP/VRP)** | Manual lane/stop sequencing; planned route via Google Maps | ❌ Not built |
+| **Driver mobile app / ELD / telematics** | GPS via inbound webhook only | ❌ Not built |
+| **Carrier self-registration / onboarding portal** | Admin creates carriers and logins | ❌ Not built |
+| **Legal-grade e-signature** | Captures POD signature image; not DocuSign-bound | 🔌 DocuSign / Adobe Sign |
+| **Predictive / ML analytics** | Rule-based ETA & automation; event-export API for downstream ML | ❌ Not built |
+| **Real-time server push (WebSocket/SSE)** | Pull/poll + in-app notifications + email | ❌ Not built |
+| **BI dashboards (Power BI/Tableau/Looker)** | CSV export + event-export API | 🔌 External BI |
+
+> **The payments example, made explicit (because it was the user's example):** an invoice can be created,
+> approved, sent, and a payment *recorded against it* (full/partial), and it can be voided. What does **not**
+> happen is the actual movement of money - no gateway charges a card, no ACH file is generated, no bank
+> reconciliation occurs. Payment *capture* and the GL live in an external finance system; Open TMS is the
+> billing system of record and the export source.
+
+---
+
+## 4. Required reporting suite
+
+What reporting the operation needs, by audience, with current status. (Gaps here feed the reporting section of
+the gap analysis.)
+
+### 4.1 Financial (finance / management)
+
+| Report | Status |
+|--------|--------|
+| AR aging (JSON + CSV) | ✅ |
+| Carrier spend summary | ✅ |
+| Margin analysis by customer | ✅ **[Broker][3PL]** |
+| CSV exports: invoice register, carrier invoice register, payment ledger, charge detail | ✅ |
+| Margin by carrier / lane / time period, target-variance | ✅ **[Broker]** |
+| Commission tracking (agent) | ✅ **[Broker]** |
+| Scheduled email delivery of financial reports | ❌ Gap (on-demand only) |
+
+### 4.2 Operational (ops / dispatch)
+
+| Report | Status |
+|--------|--------|
+| Daily ops report (Excel) | ✅ |
+| Live dashboard KPI cards | 🟡 Basic |
+| Map / control-centre view (clustering, SLA overlay) | ✅ |
+| On-time pickup % / on-time delivery % | ❌ Gap |
+| Cost per shipment / per lane trend | ❌ Gap |
+| Active-exception / dwell dashboard | 🟡 Issue kanban + SLA widget exist; no dedicated ops KPI board |
+
+### 4.3 Carrier performance (procurement)
+
+| Report | Status |
+|--------|--------|
+| Carrier scorecards (Quality Centre: by carrier/lane/location/customer) | ✅ |
+| On-time %, tender acceptance rate, claim rate per carrier | 🟡 Partial (quality metrics yes; tender-acceptance & composite score limited) |
+| Performance-based waterfall ordering | ❌ Gap |
+
+### 4.4 Compliance / quality (QA)
+
+| Report | Status |
+|--------|--------|
+| Cold-chain compliance PDF (CFR 21 Part 11) | ✅ |
+| CAPA management + 30/60/90 follow-up | ✅ |
+| SOP checklists / GDP audit | ✅ |
+| Issue closure report PDF | ✅ |
+| SLA compliance dashboard | ✅ |
+
+### 4.5 External (customer / carrier facing)
+
+| Report | Status |
+|--------|--------|
+| Customer: order/shipment status, documents, invoices, returns | ✅ (portal) |
+| Customer: shareable public tracking link (no login) | ❌ Gap |
+| Carrier: win/loss & bid history | ✅ (portal) |
+
+### 4.6 Cross-cutting
+
+| Capability | Status |
+|------------|--------|
+| Event-export API (warehouse/ML feed) | ✅ |
+| `/metrics` (read-model lag, throughput, queue depth) | ✅ |
+| CSV export on every data grid | 🟡 Some grids only |
+| Dashboard builder / saved views | 🟡 Kanban saved views only |
+| Native BI connector | 🔌 Use CSV / event-export |

--- a/docs/workflows/02-SETUP-AND-ONBOARDING.md
+++ b/docs/workflows/02-SETUP-AND-ONBOARDING.md
@@ -1,0 +1,156 @@
+# 02 - Setup & Onboarding
+
+This is the **order of operations**: what must be set up first, who does it, and the dependency chain. Setup is
+one-time; onboarding (customers, carriers, lanes) is ongoing but front-loaded.
+
+The golden rule of dependencies: **Locations before Lanes; Customers/Carriers before the work that references
+them; Carrier-on-Lane rates before tendering is meaningful; portal logins last (the parent entity must exist
+first).**
+
+---
+
+## Phase A - Bring the platform up (one-time, admin)
+
+| # | Step | Who | How | Notes |
+|---|------|-----|-----|-------|
+| A1 | Deploy + database migrated | IT/admin | `run.sh` (local) or a cloud template | Backend :3001, Frontend :5173, Postgres :55432 |
+| A2 | Create the **first admin user + Organization** | First admin | Bootstrap (see runbook). In the `run.sh` stack this is done by `npm run seed`, which also creates demo data; in a clean production deploy, `auth-service`'s `POST /api/v1/auth/setup` | Setup only works when **no users exist** |
+| A3 | Log in | Admin | `POST /api/v1/auth/login` → JWT | Use the JWT as `Authorization: Bearer <token>` for all internal API calls |
+
+---
+
+## Phase B - Configure the Organization (one-time, admin)
+
+All via `PUT /api/v1/organization/settings` (or the Admin app UI). **Set the operating model first** because it
+shapes everything after.
+
+| # | Setting | Field(s) | Model relevance |
+|---|---------|----------|-----------------|
+| B1 | **Operating model** | `organizationType` = `shipper` \| `broker` \| `3pl` \| `carrier` | Decides the workflows in doc 03 |
+| B2 | Brokerage identity | `mcNumber`, `bondAmountCents`, `bondExpirationDate`, `operatingAuthorityStatus`, `minMarginPercent`, `marginAlertEnabled` | **[Broker]** (and brokering 3PLs) |
+| B3 | Units of measure | `weightUnit`, `dimUnit`, `temperatureUnit`, `distanceUnit` | All |
+| B4 | Tracking unit model | `trackingMode` (`group`/`item`), `trackableUnitType` (`pallet`/`tote`/`box`/`stillage`/`custom`), `customUnitName` | All |
+| B5 | Operational toggles | `autoTenderEnabled`, `defaultGeofenceRadiusMeters`, `autoDeliverShipmentDocs`, `magicLinksEnabled`, `warehouseScanMode` | All |
+| B6 | Email delivery | `emailProvider` (`console`/`smtp`/`sendgrid`/`ses`), `emailEnabled`, `emailFrom*`, SMTP creds | All (keep `console` for testing) |
+| B7 | Maps key (route planning + deviation) | `googleMapsApiKey` | Needed for lane planned-routes & deviation alerts |
+| B8 | LLM key (AI triage) | `llmProvider`, `llmApiKey`, `llmModel`, `llmEnabled` | Optional; enables the triage agent |
+| B9 | Branding / white-label | logo upload, `themeConfig`, email header/footer | **[3PL]** especially (white-label) |
+
+---
+
+## Phase C - Reference data & configuration (admin / ops)
+
+These can be created in parallel once the org is configured. Several are prerequisites for later onboarding.
+
+| # | What | Endpoint / UI | Depends on |
+|---|------|---------------|-----------|
+| C1 | Internal users + role assignment | created via auth, then `POST /api/v1/roles/:roleId/users/:userId` | - |
+| C2 | Document templates (BOL, labels, customs) | Admin → Document Templates | - |
+| C3 | Custom fields (per entity) | Admin → Custom Fields | - |
+| C4 | SLA policies (org defaults + per-customer overrides) | `/api/v1/sla-*` / Admin | Customers (for overrides) |
+| C5 | Cold-chain profiles | VNext Cold Chain | - |
+| C6 | EDI Trading Partners (per partner, per transaction type) | Integrations → Trading Partners | Customers/Carriers they map to |
+| C7 | Automation rules / skills config | Admin → Automation / Skills | - |
+
+---
+
+## Phase D - Onboarding flows (ongoing)
+
+The substance of "who creates customers, how lanes get created, how carriers are onboarded." Order matters
+because of foreign keys.
+
+### D1. Locations - **do these first** (lanes and orders reference them)
+
+- **Who:** Ops. **Create:** `POST /api/v1/locations` · UI `/locations/create`.
+- **Required:** `name`, `address1`, `city`, `country`.
+- **Important optional:** `locationType` (`warehouse` | `distribution_centre` | `cross_dock` | `terminal` |
+  `port` | `rail_yard` | `customer` | `store` | `manufacturing`), `lat`/`lng` (for geofencing),
+  `facilityCapabilities`, `appointmentRequired`, `dockCount`, operating hours, contacts.
+- **Auto:** a default geofence arrival criterion is created from `defaultGeofenceRadiusMeters`. Locations are
+  also **auto-created** from raw address data on orders/shipments (name+city match or create).
+- **Per model:** **[Shipper]** own DCs + the receiver sites they deliver to. **[Broker]** pickup & delivery
+  sites (often created on the fly from order data). **[3PL]** the client's sites + the 3PL's own network nodes
+  (cross-docks/terminals).
+
+### D2. Customers - **who creates them**
+
+- **Who:** **[Shipper]** ops · **[Broker]** sales/`broker_agent` · **[3PL]** onboarding team. **No customer
+  self-registration.**
+- **Create:** `POST /api/v1/customers` · UI `/customers/create`. **Required:** `name`.
+- **Billing config** (set at create or via edit): `invoiceConsolidation` (`per_shipment`/`weekly`/`monthly`),
+  `creditLimitCents`, `paymentTermsDays` (default 30), `autoInvoice`, `currency`, `taxId`,
+  `targetMarginPercent`, billing address block.
+- **Then (optional): provision portal logins** - `POST /api/v1/customers/:customerId/users` with
+  `email`/`password`/`name`/`role` (`viewer`|`admin`). Hand the customer their login (seed uses `Portal123!`).
+- **Per model:** **[Shipper]** a "customer" is usually a *receiver*; billing config is often unused (no customer
+  AR). **[Broker]/[3PL]** the customer is the paying client - set credit limit, payment terms, consolidation,
+  and target margin, and almost always give them a portal login.
+
+### D3. Carriers - **how they're onboarded** (admin-only; no self-onboarding)
+
+1. **Create the carrier:** `POST /api/v1/carriers` · UI `/carriers/create`. **Required:** `name`. **Key:**
+   `scacCode` (needed for EDI 204), `mcNumber`, `dotNumber`, contacts, address, `paymentTermsDays`, `currency`,
+   remit-to block, optional return-label provider.
+2. **Run the validation checklist** (the onboarding gate) on the carrier record: `validationTier`
+   (`tier1`/`tier2`/`tier3`), and the booleans `registrationChecked`, `insuranceDocReceived`,
+   `insuranceVerified`, `identityConfirmed`, `complianceChecked`, plus `validationNotes`, `validatedAt`,
+   `validatedBy`. *This is the manual stand-in for a real onboarding pipeline - the docs are tracked as flags,
+   not collected through a self-service flow (see gap below).*
+3. **Add vehicles / drivers** (separate endpoints on the carrier).
+4. **Assign the carrier to lanes with rates** (D4 / LaneCarrier) - until this exists, the carrier won't surface
+   in lane-based rating or quick-assign.
+5. **Provision a portal login (optional):** `POST /api/v1/carriers/:carrierId/users` with
+   `email`/`password`/`name`/`role` (`dispatcher`|`admin`). Seed uses `Carrier123!`.
+
+   ❌ **Gap:** there is no carrier self-registration, no document-upload onboarding, no approval pipeline.
+   Onboarding is entirely admin-driven and the validation tier is a manual checklist.
+
+### D4. Lanes - **how they get created**
+
+- **Who:** Procurement / ops / pricing. **Create:** `POST /api/v1/lanes` · UI `/lanes/create`.
+- **Required:** `originId`, `destinationId` (so **D1 Locations must exist first**).
+- **Multi-stop:** add `stops[]` with sequential `order` (1,2,3…); stops cannot repeat origin/destination.
+  Optional `distance`, `notes`.
+- **Assign carriers + rates:** `POST /api/v1/lanes/:id/carriers` with `carrierId`, `price`, `currency`,
+  `serviceLevel`, `notes`; mark the primary with `assigned: true` via the PUT. **This LaneCarrier rate is what
+  feeds rating, quick-quote, and waterfall tendering.**
+- **Plan the route (optional, needs Google Maps key):** `POST /api/v1/lanes/:laneId/route/calculate` then save;
+  enables corridor-based route-deviation detection. UI: `VNextCreateLane` with a draggable Google Maps editor.
+- **Per model:** **[Shipper]/[3PL]** lanes model the recurring network with negotiated contract rates.
+  **[Broker]** may run "laneless" - relying on **auto-tender** (`autoTenderEnabled`) and the load board instead
+  of pre-built lanes, building lanes only for repeat business.
+
+### D5. Portal logins - **always last**
+
+The parent entity (Customer or Carrier) must exist before its portal user can be created. Customer users:
+`POST /api/v1/customers/:id/users`. Carrier users: `POST /api/v1/carriers/:id/users`. No self-registration in
+either case.
+
+---
+
+## Onboarding dependency graph
+
+```
+Org config (B1 model first)
+   │
+   ├── Locations ─────────────┐
+   │                          ▼
+   ├── Carriers ──► LaneCarrier rates ──► Lanes ──► (auto-tender / load board ready)
+   │      │
+   │      └── Carrier portal user
+   │
+   └── Customers ──► Customer portal user / API key
+                 └── Billing config (consolidation, credit, terms, margin)
+```
+
+---
+
+## Setup-flow gaps (raw material for the gap analysis)
+
+| Gap | Impact | Model most affected |
+|-----|--------|---------------------|
+| ❌ No carrier self-onboarding / document-collection / approval pipeline | All carrier onboarding is manual admin work; validation is a checklist of booleans | [Broker], [3PL] |
+| ❌ No customer self-registration | Every customer login is admin-provisioned | All (esp. [Broker] scaling shippers) |
+| ❌ Single-org: no per-client isolation/branding | 3PL clients share one data space and one brand surface | [3PL] |
+| 🟡 SLA/EDI/automation config is admin-only and somewhat scattered | Slows multi-customer onboarding | [3PL], [Broker] |
+| 🟡 Lane planned-route requires a Google Maps key | Route-deviation detection silently skipped without it | All |

--- a/docs/workflows/03-OPERATING-WORKFLOWS.md
+++ b/docs/workflows/03-OPERATING-WORKFLOWS.md
@@ -1,0 +1,224 @@
+# 03 - Operating Workflows
+
+The recurring day-to-day workflows once setup and onboarding are done. Each is described as **trigger →
+activities → actors → outcome**, with broker / shipper / 3PL variations and the gaps each workflow exposes.
+
+The spine that ties them together:
+
+```
+Demand in ──► Order ──► Shipment ──► Cover (tender/assign) ──► Track ──► Deliver ──► Bill ──► Cash/Pay
+   (W1)        (W1)       (W2)          (W3)                    (W4)      (W4)       (W5)     (W5/W6)
+                                                                   └────► Exceptions (W7) ◄──── Returns (W8)
+```
+
+---
+
+## W1 - Demand intake → Order
+
+**Trigger:** a need to move freight. **Outcome:** a verified Order ready to become a shipment.
+
+**Channels (all land as an `Order`):**
+- Internal manual entry - `POST /api/v1/orders` · UI `/orders/create`. Required: `orderNumber`,
+  `customerId`, origin+destination (existing IDs or inline `originData`/`destinationData` to auto-create
+  locations). Optional: `serviceLevel` (FTL/LTL), `temperatureControl`, `requiresHazmat`,
+  `specialRequirements`, and `trackableUnits[]` (preferred) or `lineItems[]`.
+- **Customer portal** self-service - `POST /api/v1/customer-portal/orders`.
+- **Customer API** - `POST /api/v1/customer-api/orders` (optional `autoAssign`).
+- **EDI 850** - inbound purchase order via the universal inbound endpoint / edi-collector.
+- **CSV bulk import** - with automatic customer/location matching.
+
+**Order status path:** `pending` → `verified` (locations resolved) → `assigned`, with `issue` (raw address
+needs matching, or no matching lane) as the siding. `cancelled` and `archived` are the terminal states.
+The full set is `ORDER_STATUSES` in `backend/src/routes/orders.ts`.
+
+| Model | Who drives intake |
+|-------|-------------------|
+| **[Shipper]** | Ops keys orders, or they arrive by EDI 850 / CSV from internal systems |
+| **[Broker]** | The shipper client submits via portal/API/EDI, or an agent keys it from an email/phone tender |
+| **[3PL]** | Each client submits via their portal/API/EDI; 3PL ops handles exceptions |
+
+**Gaps:** ❌ customers can't edit an order after submission; ❌ no order-templating/recurring-order scheduler.
+
+---
+
+## W2 - Order → Shipment
+
+**Trigger:** a verified order (or several). **Outcome:** a `draft` shipment with a route.
+
+**Activities (the conversion wizard / API):**
+- Convert one: `POST /api/v1/orders/:id/convert-to-shipment`.
+- **Combine** several orders into one shipment, or **split** one large order across shipments
+  (`/batch-convert`, `/split-to-shipments`, `/assign-to-shipment`).
+- Or create a shipment directly: `POST /api/v1/shipments` (lane *or* origin+dest, optional pre-assigned
+  `carrierId`, items, pickup/delivery windows).
+- Lane auto-match: if origin/dest match a lane, the shipment inherits it (and its carrier rates).
+
+| Model | Consolidation behaviour |
+|-------|-------------------------|
+| **[Shipper]** | Combine LTL orders heading the same lane; FTL one-to-one |
+| **[Broker]** | Usually one order → one shipment → one load to cover; consolidation is opportunistic |
+| **[3PL]** | Multi-order LTL consolidation with pro-rate billing; cross-dock staging at network nodes |
+
+**Gaps:** ❌ no load-optimisation/VRP to *suggest* consolidations - it's a manual operator decision.
+
+---
+
+## W3 - Cover the load (tender or assign)
+
+**Trigger:** a shipment needs a carrier. **Outcome:** an awarded carrier at an agreed cost.
+
+Two paths, depending on model:
+
+### Path A - Tendering (RFQ to carriers)
+- Create a tender (5-step wizard / `POST /api/v1/tenders`): strategy **broadcast** (all carriers at once) or
+  **waterfall** (sequential, auto-advance on decline/timeout), duration, target rate.
+- Carriers receive `TenderOffer`s, view them in the **carrier portal**, and **bid** (or it arrives as **EDI
+  990**). Bids compared in the admin tender detail; **award** the winner.
+- **Auto-tender:** for laneless shipments with `autoTenderEnabled`, a broadcast tender is created automatically
+  on `shipment.created`.
+
+### Path B - Direct assign / load board
+- **[Broker]** uses the **internal load board**: unmatched shipments are matched to carriers by lane rates and
+  historical usage, with **quick-assign** and a **real-time margin preview**. A **quick quote** from
+  lane-carrier rates (with markup) can drive a **quote → book** flow that lands the shipment back on the board.
+- A **rate confirmation PDF** (carrier-facing, hides the customer rate) is generated on assignment.
+
+| Model | Typical cover path |
+|-------|--------------------|
+| **[Shipper]** | Assign the contracted lane carrier; tender only when the primary declines |
+| **[Broker]** | Load board + quick-assign with margin preview; tender to spot-cover; margin alerts if below `minMarginPercent` |
+| **[3PL]** | Waterfall tender down a ranked carrier list, or assign per client routing guide |
+
+**Side effects:** awarding emits events that **auto-create a cost charge** (`TenderAwardFinancialHandler`) and,
+for **[Broker]**, surface margin. EDI 204 load tender is auto-delivered to the carrier's trading-partner config.
+
+**Gaps:** ❌ no performance-based waterfall ordering (carrier rank isn't driven by scorecards yet);
+❌ awarded carriers have no portal "accept & view load" screen (bidding only).
+
+---
+
+## W4 - Track → Deliver
+
+**Trigger:** an awarded/dispatched shipment. **Outcome:** a delivered shipment with POD and an audit trail.
+
+**Activities:**
+- **GPS / IoT tracking** - inbound webhook posts location/sensor readings; `ShipmentReadModel` carries
+  lat/lng; the map/control-centre view clusters everything live.
+- **Geofencing** - auto-arrival detection (GPS radius, WiFi SSID, BLE beacon) → auto-advances status; auto
+  **delivery** when destination arrival criteria are met.
+- **ETA monitoring** - cron, traffic-aware, adaptive polling; emits delay severity (minor/warning/critical)
+  and **route-deviation** alerts (if a lane planned-route exists).
+- **Carrier API tracking** - FedEx/UPS/DHL polling/webhooks bridge carrier status to shipment lifecycle
+  (delivery, exception, in-transit milestones).
+- **Cold chain** - immutable temperature logging, excursion detection, CAPA, compliance PDF on completion.
+- **POD** - signature/photos/notes captured at delivery.
+
+| Model | Tracking emphasis |
+|-------|-------------------|
+| **[Shipper]** | Own-fleet/contracted GPS + carrier API; internal visibility |
+| **[Broker]** | Carrier API aggregation + EDI 214 status from carriers; pass-through to customer portal |
+| **[3PL]** | Control-tower view across all clients; cold-chain & security telemetry; EDI 214 forwarded to client trading partners |
+
+**Gaps:** ❌ no real-time push (dashboards/portal poll); ❌ no shareable public tracking link; ❌ no driver app
+for field status/POD; ❌ multi-carrier *aggregation UI* is thin.
+
+---
+
+## W5 - Bill the customer (AR) - **[Broker] / [3PL] only**
+
+**Trigger:** `shipment.delivered`. **Outcome:** an invoice sent and (eventually) paid.
+
+**Activities:**
+- **Billing trigger** marks the shipment ready-to-invoice; with `autoInvoice` a draft is created.
+- **Charges** (revenue lines) are rated (lane-carrier rate + markup, or class-based LTL rating with weight
+  breaks/FAK/deficit-weight). Lifecycle: pending → approved → invoiced.
+- **Invoice lifecycle:** create → approve → send → record payment (full/partial) → (void/reissue).
+  **Consolidation** per customer: per-shipment / weekly / monthly (cron) - or manual
+  `POST /api/v1/invoices/consolidate`.
+- **EDI 810** outbound invoice; **EDI 820** inbound remittance auto-applies payments.
+- Customer can **view and dispute** invoices in the portal (→ financial query → possible credit note).
+
+**[Shipper]:** this whole workflow is typically **n/a** - a shipper isn't billing a customer; it only incurs
+carrier cost (W6). Charges still model expected vs actual cost for margin/landed-cost reporting.
+
+**Gaps:** 🔌 no payment capture (record-only); 🔌 GL/accounting is export-only; ❌ no scheduled report email.
+
+---
+
+## W6 - Pay & audit the carrier (AP)
+
+**Trigger:** a carrier invoice (manual, or **EDI 210** inbound). **Outcome:** an audited, approved, paid carrier
+invoice.
+
+**Activities:**
+- Receive carrier invoice → **automatic three-way freight audit**: tender rate vs expected charges vs the
+  carrier invoice. Auto-approve within tolerance (2%); flag discrepancies.
+- Approve → schedule carrier payment batch → record carrier payment. **[Broker]** can offer **quick pay** at a
+  configurable discount.
+- Disputes raise financial queries; resolution can issue a credit note.
+
+| Model | AP emphasis |
+|-------|-------------|
+| **[Shipper]** | Core money flow - this *is* the financial workflow |
+| **[Broker]** | AP paired with AR; margin = customer charge − carrier cost; commission accrues to the agent |
+| **[3PL]** | AP per carrier; cost allocated to the client for AR |
+
+**Gaps:** 🔌 no payment execution; 🟡 freight-audit rules limited to tolerance (no duplicate-billing /
+unauthorised-accessorial detection).
+
+---
+
+## W7 - Exceptions & SLA (runs alongside everything)
+
+**Trigger:** an exception event (delay, deviation, cold-chain excursion, cargo misdrop, SLA breach, low
+margin). **Outcome:** a resolved issue with an audit trail.
+
+**Activities:**
+- Events auto-create **Issues** (or the **AI triage agent** triages them: create/escalate/contact driver).
+- **SLA policies** (org + per-customer) with 8 rule types detect breaches (hybrid event + cron) and auto-raise
+  issues.
+- The **triage centre** kanban manages the lifecycle (open → in_progress → resolved → closed, snooze/reopen),
+  with comments, labels, CAPA, and an auto-generated **closure report PDF**.
+- **Automation rules** promoted from proven agent decisions handle recurring cases deterministically (zero LLM
+  cost) and can run **skills** (create issue, escalate, email, webhook).
+
+| Model | Exception emphasis |
+|-------|--------------------|
+| **[Shipper]** | Delivery exceptions, cold-chain, SLA to internal stakeholders |
+| **[Broker]** | Margin-alert issues, carrier-failure cover, customer comms |
+| **[3PL]** | Control-tower triage across clients; client-specific SLAs; security/tamper telemetry |
+
+**Gaps:** ❌ no full claims lifecycle (filed→investigation→settled) - only financial queries; ❌ no real-time
+alert push.
+
+---
+
+## W8 - Returns / Reverse logistics
+
+**Trigger:** a customer needs to return goods. **Outcome:** an RMA tracked like an outbound shipment, with a
+possible credit note.
+
+**Activities:**
+- Customer requests a return in the **portal** (`POST /api/v1/customer-portal/rmas`) or via **customer API**;
+  selects a delivered order, reason, and lines. Internal staff authorise it.
+- RMA lifecycle: requested → authorized → in_transit → received → inspecting → pending_refund → completed
+  (or rejected). Return **label** generated; line inspection; refund/credit note.
+- **EDI 180** (return authorization) supported.
+
+**Per model:** **[Broker]/[3PL]** expose this to clients via the portal; **[Shipper]** uses it for inbound
+returns into their own DCs.
+
+---
+
+## Workflow → gap summary
+
+| Workflow | Biggest gaps |
+|----------|--------------|
+| W1 Intake | Order edit after submit; recurring-order scheduling |
+| W2 Order→Shipment | Load/consolidation optimisation |
+| W3 Cover | Performance-based waterfall; carrier "accept load" portal screen |
+| W4 Track | Real-time push; public tracking link; driver app; multi-carrier aggregation UI |
+| W5 AR | Payment capture & GL (out of scope by design); scheduled report email |
+| W6 AP | Payment execution; advanced freight-audit rules |
+| W7 Exceptions | Full claims lifecycle; real-time alert push |
+| W8 Returns | (Most complete newer workflow; minor) |

--- a/docs/workflows/04-TEST-RUNBOOK.md
+++ b/docs/workflows/04-TEST-RUNBOOK.md
@@ -1,0 +1,249 @@
+# 04 - Test Runbook (executable)
+
+Follow this top-to-bottom to bring up Open TMS and **walk every workflow end to end**. It is written so you can
+do each step in the **UI** (preferred - you see what a real user sees) with a **curl** alternative for anything
+that's API-only or that you want to script.
+
+- **Backend:** http://localhost:3001   **API docs (Swagger):** http://localhost:3001/docs
+- **Frontend:** http://localhost:5173   **Postgres:** localhost:55432 (`tms`/`tms`/`tms`)
+- Response envelope is always `{ data, error }`.
+- Tick the `[ ]` boxes as you go. Each phase maps to a workflow in `03-OPERATING-WORKFLOWS.md`.
+
+> **Environment note.** This needs Docker (for Postgres) + Node 18+. Run it on your own machine; the managed
+> web container used to author these docs has no Docker daemon, so the stack can't be booted there.
+
+---
+
+## Phase 0 - Boot & seed
+
+```bash
+# from the repo root
+./run.sh                 # boots Postgres (Docker), runs migrations, starts backend :3001 + frontend :5173
+```
+
+In a second terminal, seed a full demo org (Meridian Global Logistics, a 3PL) with users + data:
+
+```bash
+cd backend
+npm run seed             # WIPES then seeds. Use `npm run seed:keep` to seed without wiping.
+```
+
+Seed gives you these logins (all internal users password `Password1!`):
+
+| Email | Role |
+|-------|------|
+| `admin@meridian-tms.demo` | admin |
+| `dispatch@meridian-tms.demo` | dispatcher |
+| `ops-manager@meridian-tms.demo` | admin |
+| `warehouse@meridian-tms.demo` | warehouse |
+| `finance@meridian-tms.demo` | admin |
+
+Plus **customer portal** users (`Portal123!`) and **carrier portal** users (`Carrier123!`).
+
+- [ ] `./run.sh` prints "Open TMS is running!" and `/docs` loads.
+- [ ] `npm run seed` finishes and prints the demo credentials.
+
+**Get an API token** (used by every curl below):
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:3001/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@meridian-tms.demo","password":"Password1!"}' | sed 's/.*"token":"\([^"]*\)".*/\1/')
+echo "$TOKEN" | cut -c1-20      # sanity check: should print the start of a JWT
+AUTH="Authorization: Bearer $TOKEN"
+```
+
+- [ ] Log in to the **UI** at http://localhost:5173 with `admin@meridian-tms.demo` / `Password1!`.
+
+---
+
+## Phase 1 - Confirm the operating model (doc 02, Phase B)
+
+```bash
+curl -s http://localhost:3001/api/v1/organization/settings -H "$AUTH" | grep -o '"organizationType":"[^"]*"'
+```
+
+To test each variant, set the model (this is the one switch that reshapes the workflows):
+
+```bash
+# choose one: shipper | broker | 3pl
+curl -s -X PUT http://localhost:3001/api/v1/organization/settings -H "$AUTH" \
+  -H 'Content-Type: application/json' -d '{"organizationType":"broker"}' | grep -o '"organizationType":"[^"]*"'
+```
+
+- [ ] Settings load; `organizationType` reads back what you set.
+- [ ] **[Broker]** also set `minMarginPercent` and `marginAlertEnabled:true` to exercise margin alerts later.
+
+---
+
+## Phase 2 - Onboarding (doc 02, Phase D) - order matters
+
+Seed already created locations/customers/carriers/lanes, so you can **either** verify those **or** create fresh
+ones to feel the dependency chain. To create fresh, follow D1→D5 in order.
+
+### 2.1 Location (first - lanes & orders depend on it)
+- **UI:** `/locations/create` → fill name/address1/city/country, pick `locationType`, set lat/lng.
+- **curl:**
+```bash
+curl -s -X POST http://localhost:3001/api/v1/locations -H "$AUTH" -H 'Content-Type: application/json' -d '{
+  "name":"Test DC East","address1":"100 Dock Rd","city":"Newark","state":"NJ","country":"US",
+  "locationType":"distribution_centre","lat":40.7357,"lng":-74.1724}'
+```
+- [ ] Location appears in `/locations`. Repeat for a destination location.
+
+### 2.2 Customer (+ billing config + portal login)
+- **UI:** `/customers/create` → name; then edit to set `invoiceConsolidation`, `creditLimitCents`,
+  `paymentTermsDays`, `autoInvoice`, `targetMarginPercent`.
+- **curl:**
+```bash
+CUST=$(curl -s -X POST http://localhost:3001/api/v1/customers -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"name":"Acme Retail","paymentTermsDays":30,"invoiceConsolidation":"per_shipment","autoInvoice":true}' \
+  | sed 's/.*"id":"\([^"]*\)".*/\1/')
+# provision a portal login
+curl -s -X POST http://localhost:3001/api/v1/customers/$CUST/users -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"email":"buyer@acme.test","password":"Portal123!","name":"Acme Buyer","role":"admin"}'
+```
+- [ ] Customer in `/customers`; portal user created. **No self-registration** - you (admin) created it.
+
+### 2.3 Carrier (+ validation + portal login)
+- **UI:** `/carriers/create` → name, `scacCode`, `mcNumber`; then on the detail page set the validation tier
+  flags (`registrationChecked`, `insuranceVerified`, `identityConfirmed`, `complianceChecked`) and add a portal
+  user via the Carrier User Management panel.
+- **curl:**
+```bash
+CARR=$(curl -s -X POST http://localhost:3001/api/v1/carriers -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"name":"Swift Test Lines","scacCode":"SWFT","mcNumber":"MC-100200","validationTier":"tier1","insuranceVerified":true}' \
+  | sed 's/.*"id":"\([^"]*\)".*/\1/')
+curl -s -X POST http://localhost:3001/api/v1/carriers/$CARR/users -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"email":"dispatch@swift.test","password":"Carrier123!","name":"Swift Dispatch","role":"dispatcher"}'
+```
+- [ ] Carrier created; validation flags set (this is the manual onboarding gate); portal login created.
+
+### 2.4 Lane (+ carrier rate)
+- **UI:** `/lanes/create` → pick origin + destination (the two locations above), add multi-stop if wanted; then
+  on the lane detail assign the carrier with a `price`.
+- **curl:** (replace ORIG/DEST with real location IDs from `GET /api/v1/locations`)
+```bash
+LANE=$(curl -s -X POST http://localhost:3001/api/v1/lanes -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"originId":"ORIG","destinationId":"DEST","distance":350}' | sed 's/.*"id":"\([^"]*\)".*/\1/')
+curl -s -X POST http://localhost:3001/api/v1/lanes/$LANE/carriers -H "$AUTH" -H 'Content-Type: application/json' \
+  -d "{\"carrierId\":\"$CARR\",\"price\":1200,\"currency\":\"USD\",\"serviceLevel\":\"standard\",\"assigned\":true}"
+```
+- [ ] Lane shows the assigned carrier and rate. (Optional: `POST /api/v1/lanes/$LANE/route/calculate` if a
+  Google Maps key is configured - otherwise route-deviation detection is skipped.)
+
+---
+
+## Phase 3 - W1/W2: Order → Shipment
+
+- **UI:** `/orders/create` → customer, origin/destination, service level, add a trackable unit with a line
+  item → save. Then open the order and **Convert to shipment**.
+- **curl:**
+```bash
+ORD=$(curl -s -X POST http://localhost:3001/api/v1/orders -H "$AUTH" -H 'Content-Type: application/json' -d "{
+  \"orderNumber\":\"TEST-0001\",\"customerId\":\"$CUST\",\"originId\":\"ORIG\",\"destinationId\":\"DEST\",
+  \"serviceLevel\":\"FTL\",\"trackableUnits\":[{\"identifier\":\"PLT-1\",\"unitType\":\"pallet\",
+  \"lineItems\":[{\"sku\":\"SKU-1\",\"quantity\":10,\"weight\":50,\"weightUnit\":\"kg\"}]}]}" \
+  | sed 's/.*"id":"\([^"]*\)".*/\1/')
+SHIP=$(curl -s -X POST http://localhost:3001/api/v1/orders/$ORD/convert-to-shipment -H "$AUTH" \
+  | sed 's/.*"id":"\([^"]*\)".*/\1/')
+```
+- [ ] Order reaches `verified`; conversion yields a `draft` shipment that inherits the lane + carrier rate.
+- [ ] **Also test the customer self-service path:** log into `/customer-portal` as `buyer@acme.test` /
+  `Portal123!` and submit an order. Confirm it appears for internal ops.
+
+---
+
+## Phase 4 - W3: Cover the load (tender + carrier portal bid)
+
+- **UI (admin):** create a tender from the shipment (5-step wizard) - choose **broadcast** or **waterfall**,
+  set duration + target rate, send.
+- **UI (carrier):** open a new browser/incognito → `/carrier-portal` → log in as `dispatch@swift.test` /
+  `Carrier123!` → open the tender → **submit a bid** (rate, transit days, equipment).
+- **UI (admin):** in tender detail, compare bids → **award** the winner.
+- [ ] Carrier sees the offer in the portal and can bid/decline.
+- [ ] Award succeeds; a **cost charge** is auto-created on the shipment (check the shipment Financial tab).
+- [ ] **[Broker]** margin preview shows on the load board / shipment; if below `minMarginPercent`, a margin
+  issue is auto-created.
+- [ ] **[Broker]** generate the **rate confirmation PDF** and confirm the customer rate is hidden.
+
+---
+
+## Phase 5 - W4: Track → Deliver
+
+Simulate GPS pings to drive geofence arrival + delivery. Find the tracking webhook in `/docs` (search
+"webhook"/"tracking"); typical shape:
+
+```bash
+# push a location near the destination geofence to trigger auto-arrival/delivery
+curl -s -X POST http://localhost:3001/api/v1/webhooks/tracking -H 'Content-Type: application/json' -d "{
+  \"shipmentId\":\"$SHIP\",\"lat\":40.7357,\"lng\":-74.1724,\"timestamp\":\"$(date -u +%FT%TZ)\"}"
+```
+
+- [ ] Shipment status advances; arriving inside the destination geofence auto-delivers it.
+- [ ] The map/control-centre view (`/` ops map) shows the shipment moving.
+- [ ] Customer can track it in `/customer-portal` (status, stops, recent events).
+- [ ] (If cold-chain profile assigned) a compliance PDF is generated on completion.
+
+---
+
+## Phase 6 - W5/W6: Billing (AR) & Carrier audit (AP)
+
+**AR (customer invoice)** - **[Broker]/[3PL]**:
+- On delivery, the billing trigger marks the shipment ready-to-invoice (auto-draft if `autoInvoice`).
+- **UI (finance):** VNext Finance → approve the draft → send. Or `POST /api/v1/invoices/consolidate`.
+- **Customer portal:** as `buyer@acme.test`, view the invoice and **raise a dispute** → confirm a financial
+  query is created internally.
+
+**AP (carrier invoice + freight audit)**:
+- **UI/curl:** receive a carrier invoice (or post **EDI 210**) → three-way audit runs (tender vs expected vs
+  invoice) → auto-approve within 2% or flag.
+- [ ] AR: invoice created → approved → sent → customer sees it → dispute creates a query.
+- [ ] AP: carrier invoice received → freight audit result visible → approve → record payment.
+- [ ] Confirm **no real payment is processed** - payment is *recorded only* (out of scope by design).
+
+---
+
+## Phase 7 - W7: Exceptions, SLA & triage
+
+- Trigger an exception: let a shipment blow an SLA (or post a delay), or trip a cold-chain excursion.
+- [ ] An **Issue** is auto-created (or the **AI triage agent** triages it, if `llmEnabled` + key set).
+- [ ] The issue appears on the triage **kanban**; move it open → in_progress → resolved → closed.
+- [ ] Closing generates a **closure report PDF**.
+- [ ] (Optional) promote a triage decision to an **automation rule** and confirm the next matching event is
+  handled deterministically (no LLM call).
+
+---
+
+## Phase 8 - W8: Returns / RMA
+
+- **Customer portal:** as `buyer@acme.test`, request a return against a delivered order (reason + lines).
+- **UI (internal):** authorise the RMA → generate the return label → mark received → inspect → refund/credit.
+- [ ] RMA walks requested → authorized → in_transit → received → inspecting → completed.
+- [ ] A return label is generated; a credit note can be issued on completion.
+
+---
+
+## Phase 9 - External-task sweep (portals & API)
+
+- [ ] **Carrier portal:** login, view tenders, bid, decline, bid/tender history, change password. Confirm there
+  is **no** "accept awarded load" screen and **no** POD capture (known gaps).
+- [ ] **Customer portal:** orders, shipment tracking, document download, invoice view + dispute, returns, and
+  the **Developer area** (create an API key, register a webhook, send a test, view the EDI log).
+- [ ] **Customer API:** with a created API key, `POST /api/v1/customer-api/orders` and
+  `GET /api/v1/customer-api/orders/:id/status`.
+
+---
+
+## What "done" looks like
+
+You've created the full chain (location → customer → carrier → lane → order → shipment → tender → award →
+track → deliver → invoice → pay → return), exercised both portals, and confirmed the scope boundaries hold
+(payments recorded not processed; no carrier self-onboarding; single-org). Every box ticked = the platform's
+core operating loop works on your machine.
+
+## Issues you hit → gap analysis
+
+Keep a scratch list as you run this. Anywhere a step needed a manual workaround, an API-only action with no UI,
+or simply couldn't be done, note it against the W-number. That list, combined with the ❌ flags in docs 01-03,
+is the input to the **workflow-lens gap analysis** (the next deliverable).

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -1,0 +1,62 @@
+# Open TMS - Workflows, Tasks & Activities
+
+> **Purpose.** This folder defines *how Open TMS is operated*, not just what features exist. It answers the
+> process questions: what happens first, who sets what up, who creates customers, how lanes get created, how
+> carriers are onboarded, what tasks carriers and customers do on the platform, what is deliberately **out of
+> scope**, and what reporting the operation needs.
+>
+> It is written against the **actual current system** (verified in code, June 2026), not the older
+> `docs/gap-analysis/` feature comparison, which is now stale in several places (most notably the customer
+> portal, which is far more complete than that document claims).
+
+## How this is organised
+
+| File | What it covers |
+|------|----------------|
+| [01-ACTORS-ROLES-SCOPE.md](./01-ACTORS-ROLES-SCOPE.md) | The actors (internal roles, external portal users, system/automation), a RACI per operating model, the explicit **in-scope / out-of-scope** boundary, and the **required reporting suite**. |
+| [02-SETUP-AND-ONBOARDING.md](./02-SETUP-AND-ONBOARDING.md) | The one-time **setup sequence** (who configures what, in order) and the **onboarding flows** for customers, locations, lanes, carriers, and portal users. |
+| [03-OPERATING-WORKFLOWS.md](./03-OPERATING-WORKFLOWS.md) | The recurring **operating workflows**: order-to-cash, tender-to-award, track-to-deliver, exception handling, returns - with the broker / shipper / 3PL variations called out. |
+| [04-TEST-RUNBOOK.md](./04-TEST-RUNBOOK.md) | An **executable, step-by-step runbook** you can follow against a running instance to walk through and validate every workflow end to end. Start here when you want to *do* it. |
+
+## The three operating models
+
+Open TMS is one platform configured for three different operating models. The model is set by
+`organizationType` on the Organization (`shipper` | `broker` | `3pl` | `carrier`), via
+`PUT /api/v1/organization/settings`. The model changes **who owns each step** - especially who creates
+customers and who books freight - but the underlying entities are the same.
+
+| Tag | Model | Who runs the instance | "Customer" means | "Carrier" means | Primary money flow |
+|-----|-------|-----------------------|------------------|-----------------|--------------------|
+| **[Shipper]** | Shipper-run | A company managing its own freight | A consignee / receiving party / internal business unit they ship to | A contracted haulier they pay | They pay carriers (cost only; no customer AR) |
+| **[Broker]** | Broker-first | A freight broker / 3PL brokerage | A shipper client who pays the broker | A haulier the broker covers the load with | Customer pays broker (AR), broker pays carrier (AP), broker keeps margin |
+| **[3PL]** | 3PL / control tower | A 3PL managing logistics for multiple client shippers | A client shipper (each client = one Customer record today) | A haulier in the 3PL's carrier base | Client pays 3PL (AR), 3PL pays carrier (AP); often white-labelled |
+
+Throughout these docs, a step that differs by model is marked with the tags above. A step with no tag applies
+to all three.
+
+> **Tenancy note (important for 3PL).** This section originally described the platform as
+> single-organization. That is **no longer true**: every tenant-scoped model now carries a NOT NULL `orgId`,
+> routes scope through `registerOrgScope` / `req.orgId`, and cross-tenant isolation is covered by tests in
+> `backend/src/__tests__/integration/`. See the multi-tenancy section of `CLAUDE.md`.
+>
+> Within a single organization, the 3PL model is still expressed by representing each client shipper as a
+> `Customer` record rather than as its own Organization. Choosing between "one Organization per 3PL, clients
+> as Customers" and "one Organization per client" is a deployment decision, not a platform limitation.
+
+## How to use these docs
+
+- **Designing / reviewing the operating model?** Read 01 → 02 → 03 in order.
+- **Want to start working through and testing it right now?** Go straight to
+  [04-TEST-RUNBOOK.md](./04-TEST-RUNBOOK.md). It boots the stack, seeds demo data, and walks every workflow.
+- **Building a gap analysis?** 01 (scope) and 03 (workflows) flag every place where a workflow has a missing
+  step, a manual workaround, or a handoff hole. Those flags are the raw material for the workflow-lens gap
+  analysis (the next deliverable after this spec).
+
+## Status legend used throughout
+
+| Marker | Meaning |
+|--------|---------|
+| ✅ Built | Works today, UI + API present |
+| 🟡 Partial | Exists but incomplete or API-only / manual workaround needed |
+| 🔌 Integration | Deliberately delegated to an external system (out of scope to build) |
+| ❌ Gap | Needed by the workflow but not built - candidate for the gap analysis |


### PR DESCRIPTION
## What

Adds `docs/workflows/`, which had no equivalent anywhere in `docs/`:

| File | Covers |
|---|---|
| `01-ACTORS-ROLES-SCOPE.md` | Actors, RACI per operating model, in/out-of-scope boundary, reporting suite |
| `02-SETUP-AND-ONBOARDING.md` | One-time setup sequence and onboarding flows |
| `03-OPERATING-WORKFLOWS.md` | Operating workflows W1-W8 with shipper / broker / 3PL variants |
| `04-TEST-RUNBOOK.md` | Step-by-step runbook to walk every workflow against a running instance |

## Staleness corrected before landing

Salvaged from `claude/open-tms-workflows-gaps-c6dq87` (`243bfa7`), written June 2026 and 94 commits behind. Two things had gone stale; both fixed against current main:

- **Order lifecycle** was documented as `pending → validated → assigned/converted` with `location_error` and `pending_lane` sidings. It is now `pending → verified → assigned` with `issue` as the siding, per `ORDER_STATUSES` in `backend/src/routes/orders.ts`.
- **Tenancy** was described as single-organization, with multi-tenant isolation listed as an out-of-scope "architectural gap (biggest 3PL limit)". Multi-tenancy has since landed (NOT NULL `orgId`, `registerOrgScope`, cross-tenant isolation tests), so the caveat is rewritten and the out-of-scope row removed.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)