### PR TITLE
Org-scope every warehouse route and require auth on magic-link generate (#130)

### DIFF
--- a/backend/src/__tests__/services/WarehouseService.test.ts
+++ b/backend/src/__tests__/services/WarehouseService.test.ts
@@ -51,7 +51,7 @@ const mockFlag = {
 function createMockPrisma(overrides: any = {}) {
   return {
     organization: {
-      findFirst: jest.fn().mockResolvedValue({ magicLinksEnabled: true }),
+      findUnique: jest.fn().mockResolvedValue({ id: 'org-1', magicLinksEnabled: true }),
     },
     user: {
       findUnique: jest.fn().mockResolvedValue(mockUser),
@@ -72,7 +72,7 @@ function createMockPrisma(overrides: any = {}) {
     },
     shipmentFlag: {
       create: jest.fn().mockResolvedValue(mockFlag),
-      findUnique: jest.fn().mockResolvedValue(mockFlag),
+      findFirst: jest.fn().mockResolvedValue(mockFlag),
       update: jest.fn().mockResolvedValue({ ...mockFlag, resolved: true }),
       count: jest.fn().mockResolvedValue(0),
     },
@@ -85,7 +85,7 @@ function createMockPrisma(overrides: any = {}) {
     },
     shipmentAccessory: {
       create: jest.fn().mockResolvedValue({ id: 'acc-1', accessoryType: 'door_seal' }),
-      delete: jest.fn().mockResolvedValue({}),
+      deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
     ...overrides,
   };
@@ -107,7 +107,7 @@ describe('WarehouseService', () => {
 
   describe('generateMagicLink', () => {
     it('generates a magic link token for a valid user', async () => {
-      const result = await service.generateMagicLink('user-1');
+      const result = await service.generateMagicLink('user-1', 'org-1');
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -120,7 +120,7 @@ describe('WarehouseService', () => {
     });
 
     it('deactivates existing magic links before creating a new one', async () => {
-      await service.generateMagicLink('user-1');
+      await service.generateMagicLink('user-1', 'org-1');
 
       expect(prisma.magicLink.updateMany).toHaveBeenCalledWith({
         where: { userId: 'user-1', active: true },
@@ -129,7 +129,7 @@ describe('WarehouseService', () => {
     });
 
     it('stores a SHA-256 hash of the token, not the token itself', async () => {
-      const result = await service.generateMagicLink('user-1');
+      const result = await service.generateMagicLink('user-1', 'org-1');
       expect(result.success).toBe(true);
 
       const createCall = prisma.magicLink.create.mock.calls[0][0];
@@ -140,7 +140,7 @@ describe('WarehouseService', () => {
     });
 
     it('sets expiry when expiresInDays is provided', async () => {
-      const result = await service.generateMagicLink('user-1', 30);
+      const result = await service.generateMagicLink('user-1', 'org-1', 30);
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -151,9 +151,9 @@ describe('WarehouseService', () => {
     });
 
     it('fails if magic links are disabled', async () => {
-      prisma.organization.findFirst.mockResolvedValue({ magicLinksEnabled: false });
+      prisma.organization.findUnique.mockResolvedValue({ id: 'org-1', magicLinksEnabled: false });
 
-      const result = await service.generateMagicLink('user-1');
+      const result = await service.generateMagicLink('user-1', 'org-1');
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -164,7 +164,7 @@ describe('WarehouseService', () => {
     it('fails if user not found', async () => {
       prisma.user.findUnique.mockResolvedValue(null);
 
-      const result = await service.generateMagicLink('user-999');
+      const result = await service.generateMagicLink('user-999', 'org-1');
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -175,7 +175,7 @@ describe('WarehouseService', () => {
     it('fails if user is inactive', async () => {
       prisma.user.findUnique.mockResolvedValue({ ...mockUser, active: false });
 
-      const result = await service.generateMagicLink('user-1');
+      const result = await service.generateMagicLink('user-1', 'org-1');
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -480,7 +480,7 @@ describe('WarehouseService', () => {
 
   describe('flagShipment', () => {
     it('creates a flag on an existing shipment', async () => {
-      const result = await service.flagShipment('ship-1', 'user-1', 'Jane Worker', 'Wrong pallet count');
+      const result = await service.flagShipment('ship-1', 'org-1', 'user-1', 'Jane Worker', 'Wrong pallet count');
 
       expect(result.success).toBe(true);
       expect(prisma.shipmentFlag.create).toHaveBeenCalledWith({
@@ -496,7 +496,7 @@ describe('WarehouseService', () => {
     it('fails if shipment not found', async () => {
       prisma.shipment.findFirst.mockResolvedValue(null);
 
-      const result = await service.flagShipment('ship-999', 'user-1', 'Jane', 'Issue');
+      const result = await service.flagShipment('ship-999', 'org-1', 'user-1', 'Jane', 'Issue');
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -507,14 +507,14 @@ describe('WarehouseService', () => {
     it('fails if shipment is archived', async () => {
       prisma.shipment.findFirst.mockResolvedValue(null); // archived filter excludes it
 
-      const result = await service.flagShipment('ship-1', 'user-1', 'Jane', 'Issue');
+      const result = await service.flagShipment('ship-1', 'org-1', 'user-1', 'Jane', 'Issue');
       expect(result.success).toBe(false);
     });
   });
 
   describe('resolveFlag', () => {
     it('resolves an existing flag', async () => {
-      const result = await service.resolveFlag('flag-1', 'admin-1');
+      const result = await service.resolveFlag('flag-1', 'org-1', 'admin-1');
 
       expect(result.success).toBe(true);
       expect(prisma.shipmentFlag.update).toHaveBeenCalledWith(
@@ -526,9 +526,9 @@ describe('WarehouseService', () => {
     });
 
     it('fails if flag not found', async () => {
-      prisma.shipmentFlag.findUnique.mockResolvedValue(null);
+      prisma.shipmentFlag.findFirst.mockResolvedValue(null);
 
-      const result = await service.resolveFlag('flag-999', 'admin-1');
+      const result = await service.resolveFlag('flag-999', 'org-1', 'admin-1');
       expect(result.success).toBe(false);
     });
   });
@@ -537,7 +537,7 @@ describe('WarehouseService', () => {
 
   describe('launchShipment', () => {
     it('launches a draft shipment and transitions to ready', async () => {
-      const result = await service.launchShipment('ship-1', 'user-1');
+      const result = await service.launchShipment('ship-1', 'org-1', 'user-1');
 
       expect(result.success).toBe(true);
       expect(prisma.shipment.update).toHaveBeenCalledWith(
@@ -555,7 +555,7 @@ describe('WarehouseService', () => {
     it('preserves non-draft status when launching', async () => {
       prisma.shipment.findFirst.mockResolvedValue({ ...mockShipment, status: 'picked' });
 
-      await service.launchShipment('ship-1', 'user-1');
+      await service.launchShipment('ship-1', 'org-1', 'user-1');
 
       expect(prisma.shipment.update).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -567,7 +567,7 @@ describe('WarehouseService', () => {
     it('fails if shipment not found', async () => {
       prisma.shipment.findFirst.mockResolvedValue(null);
 
-      const result = await service.launchShipment('ship-999', 'user-1');
+      const result = await service.launchShipment('ship-999', 'org-1', 'user-1');
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error).toContain('not found');
@@ -577,7 +577,7 @@ describe('WarehouseService', () => {
     it('blocks launch when unresolved flags exist', async () => {
       prisma.shipmentFlag.count.mockResolvedValue(2);
 
-      const result = await service.launchShipment('ship-1', 'user-1');
+      const result = await service.launchShipment('ship-1', 'org-1', 'user-1');
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -589,7 +589,7 @@ describe('WarehouseService', () => {
     it('allows launch when all flags are resolved', async () => {
       prisma.shipmentFlag.count.mockResolvedValue(0);
 
-      const result = await service.launchShipment('ship-1', 'user-1');
+      const result = await service.launchShipment('ship-1', 'org-1', 'user-1');
       expect(result.success).toBe(true);
     });
   });
@@ -598,7 +598,7 @@ describe('WarehouseService', () => {
 
   describe('lookupDevice', () => {
     it('finds device by externalId barcode', async () => {
-      const result = await service.lookupDevice('SL-TRACKER-001');
+      const result = await service.lookupDevice('SL-TRACKER-001', 'org-1');
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -624,7 +624,7 @@ describe('WarehouseService', () => {
         assignments: [{ shipment: { id: 'ship-2', reference: 'SH-002' } }],
       });
 
-      const result = await service.lookupDevice('SL-TRACKER-001');
+      const result = await service.lookupDevice('SL-TRACKER-001', 'org-1');
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -636,7 +636,7 @@ describe('WarehouseService', () => {
     it('fails if device not found', async () => {
       prisma.device.findFirst.mockResolvedValue(null);
 
-      const result = await service.lookupDevice('UNKNOWN-BARCODE');
+      const result = await service.lookupDevice('UNKNOWN-BARCODE', 'org-1');
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -649,7 +649,7 @@ describe('WarehouseService', () => {
 
   describe('assignDeviceToShipment', () => {
     it('deactivates existing assignments and creates a new one', async () => {
-      const result = await service.assignDeviceToShipment('ship-1', 'dev-1');
+      const result = await service.assignDeviceToShipment('ship-1', 'dev-1', 'org-1');
 
       expect(result.success).toBe(true);
       expect(prisma.deviceAssignment.updateMany).toHaveBeenCalledWith({
@@ -666,7 +666,7 @@ describe('WarehouseService', () => {
     });
 
     it('assigns to a trackable unit when provided', async () => {
-      await service.assignDeviceToShipment('ship-1', 'dev-1', 'unit-42');
+      await service.assignDeviceToShipment('ship-1', 'dev-1', 'org-1', 'unit-42');
 
       expect(prisma.deviceAssignment.create).toHaveBeenCalledWith({
         data: expect.objectContaining({ trackableUnitId: 'unit-42' }),
@@ -676,11 +676,11 @@ describe('WarehouseService', () => {
 
   describe('removeDeviceFromShipment', () => {
     it('deactivates the assignment for the specific shipment', async () => {
-      const result = await service.removeDeviceFromShipment('ship-1', 'dev-1');
+      const result = await service.removeDeviceFromShipment('ship-1', 'dev-1', 'org-1');
 
       expect(result.success).toBe(true);
       expect(prisma.deviceAssignment.updateMany).toHaveBeenCalledWith({
-        where: { deviceId: 'dev-1', shipmentId: 'ship-1', active: true },
+        where: { deviceId: 'dev-1', shipmentId: 'ship-1', active: true, shipment: { orgId: 'org-1' } },
         data: expect.objectContaining({ active: false }),
       });
     });
@@ -690,7 +690,7 @@ describe('WarehouseService', () => {
 
   describe('addAccessory', () => {
     it('creates a non-IoT door seal', async () => {
-      const result = await service.addAccessory('ship-1', {
+      const result = await service.addAccessory('ship-1', 'org-1', {
         accessoryType: 'door_seal',
         identifier: 'SEAL-12345',
         isIoT: false,
@@ -709,7 +709,7 @@ describe('WarehouseService', () => {
     });
 
     it('creates an IoT temperature sensor with device reference', async () => {
-      const result = await service.addAccessory('ship-1', {
+      const result = await service.addAccessory('ship-1', 'org-1', {
         accessoryType: 'temp_sensor_front',
         alias: 'Front Temp',
         isIoT: true,
@@ -730,10 +730,12 @@ describe('WarehouseService', () => {
 
   describe('removeAccessory', () => {
     it('deletes the accessory record', async () => {
-      const result = await service.removeAccessory('acc-1');
+      const result = await service.removeAccessory('acc-1', 'org-1');
 
       expect(result.success).toBe(true);
-      expect(prisma.shipmentAccessory.delete).toHaveBeenCalledWith({ where: { id: 'acc-1' } });
+      expect(prisma.shipmentAccessory.deleteMany).toHaveBeenCalledWith({
+        where: { id: 'acc-1', shipment: { orgId: 'org-1' } },
+      });
     });
   });
 
@@ -770,6 +772,95 @@ describe('WarehouseService', () => {
           success: false, failReason: 'test',
         })
       ).resolves.toBeUndefined();
+    });
+  });
+
+  // ─── Org Scoping (Tenancy) ────────────────────────────────────────────
+  // Every method takes the caller's orgId and must scope reads and writes
+  // to it. Cross-tenant ids read as "not found" so existence stays opaque.
+
+  describe('org scoping', () => {
+    it('generateMagicLink resolves the caller org by id, never findFirst', async () => {
+      await service.generateMagicLink('user-1', 'org-1');
+      expect(prisma.organization.findUnique).toHaveBeenCalledWith({ where: { id: 'org-1' } });
+    });
+
+    it('generateMagicLink refuses a user belonging to another org', async () => {
+      prisma.user.findUnique.mockResolvedValue({ ...mockUser, organizationId: 'org-2' });
+
+      const result = await service.generateMagicLink('user-1', 'org-1');
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe('User not found or inactive');
+      expect(prisma.magicLink.create).not.toHaveBeenCalled();
+    });
+
+    it('flagShipment scopes the shipment lookup to the org', async () => {
+      await service.flagShipment('ship-1', 'org-1', 'user-1', 'Jane', 'Issue');
+      expect(prisma.shipment.findFirst).toHaveBeenCalledWith({
+        where: { id: 'ship-1', orgId: 'org-1', archived: false },
+      });
+    });
+
+    it('resolveFlag scopes the flag lookup through the shipment org', async () => {
+      await service.resolveFlag('flag-1', 'org-1', 'admin-1');
+      expect(prisma.shipmentFlag.findFirst).toHaveBeenCalledWith({
+        where: { id: 'flag-1', shipment: { orgId: 'org-1' } },
+      });
+    });
+
+    it('launchShipment scopes the shipment lookup to the org', async () => {
+      await service.launchShipment('ship-1', 'org-1', 'user-1');
+      expect(prisma.shipment.findFirst).toHaveBeenCalledWith({
+        where: { id: 'ship-1', orgId: 'org-1', archived: false },
+      });
+    });
+
+    it('lookupDevice scopes the device lookup to the org', async () => {
+      await service.lookupDevice('SL-TRACKER-001', 'org-1');
+      expect(prisma.device.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ orgId: 'org-1' }),
+        }),
+      );
+    });
+
+    it('assignDeviceToShipment refuses a cross-org shipment and writes nothing', async () => {
+      prisma.shipment.findFirst.mockResolvedValue(null);
+
+      const result = await service.assignDeviceToShipment('ship-other-org', 'dev-1', 'org-1');
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe('Shipment not found');
+      expect(prisma.deviceAssignment.updateMany).not.toHaveBeenCalled();
+      expect(prisma.deviceAssignment.create).not.toHaveBeenCalled();
+    });
+
+    it('assignDeviceToShipment refuses a cross-org device and writes nothing', async () => {
+      prisma.device.findFirst.mockResolvedValue(null);
+
+      const result = await service.assignDeviceToShipment('ship-1', 'dev-other-org', 'org-1');
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe('Device not found');
+      expect(prisma.deviceAssignment.create).not.toHaveBeenCalled();
+    });
+
+    it('removeDeviceFromShipment scopes the deactivation through the shipment org', async () => {
+      await service.removeDeviceFromShipment('ship-1', 'dev-1', 'org-1');
+      expect(prisma.deviceAssignment.updateMany).toHaveBeenCalledWith({
+        where: { deviceId: 'dev-1', shipmentId: 'ship-1', active: true, shipment: { orgId: 'org-1' } },
+        data: expect.objectContaining({ active: false }),
+      });
+    });
+
+    it('addAccessory refuses a cross-org shipment', async () => {
+      prisma.shipment.findFirst.mockResolvedValue(null);
+
+      const result = await service.addAccessory('ship-other-org', 'org-1', { accessoryType: 'door_seal' });
+
+      expect(result.success).toBe(false);
+      expect(prisma.shipmentAccessory.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/routes/warehouse.ts
+++ b/backend/src/routes/warehouse.ts
@@ -17,12 +17,11 @@ export async function warehouseRoutes(server: FastifyInstance) {
   const warehouseService = new WarehouseService(prisma);
 
   // Auth — every operational warehouse route requires a valid session JWT.
-  // The three login endpoints below are excluded (they're the way to GET
-  // the JWT in the first place), as is the admin magic-link generate
-  // endpoint (separate-concern admin action — TODO: wire it to a stricter
-  // admin role check instead of leaving it unauthed).
+  // Only the two login endpoints are excluded (they're the way to GET the
+  // JWT in the first place). Magic-link generate is an admin action and
+  // requires auth like everything else: an unauthenticated generate
+  // endpoint would let anyone mint a login link for any user.
   const unauthPaths = new Set<string>([
-    '/api/v1/warehouse/auth/magic-link/generate',
     '/api/v1/warehouse/auth/magic-link/validate',
     '/api/v1/warehouse/auth/login',
   ]);
@@ -66,7 +65,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
       expiresInDays: z.number().positive().optional(),
     }).parse(req.body);
 
-    const result = await warehouseService.generateMagicLink(body.userId, body.expiresInDays);
+    const result = await warehouseService.generateMagicLink(body.userId, req.orgId!, body.expiresInDays);
     if (!result.success) {
       reply.code(result.error.includes('disabled') ? 403 : 404);
       return { data: null, error: result.error };
@@ -174,13 +173,16 @@ export async function warehouseRoutes(server: FastifyInstance) {
       preferredLocationId: z.string().uuid().nullable().optional(),
     }).parse(req.body);
 
-    const user = await prisma.user.update({
-      where: { id },
+    const updated = await prisma.user.updateMany({
+      where: { id, organizationId: req.orgId! },
       data: { preferredLocationId: body.preferredLocationId },
-      select: { id: true, preferredLocationId: true },
     });
+    if (updated.count === 0) {
+      reply.code(404);
+      return { data: null, error: 'User not found' };
+    }
 
-    return { data: user, error: null };
+    return { data: { id, preferredLocationId: body.preferredLocationId ?? null }, error: null };
   });
 
   // ─── Shipment List (Today's Work) ─────────────────────────────────────────
@@ -215,6 +217,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
     const twoDaysAgo = new Date(Date.now() - 2 * 86400000);
 
     const where: any = {
+      orgId: req.orgId!,
       archived: false,
       // Only show draft/ready shipments (not in_transit/delivered)
       status: { in: ['draft', 'ready', 'picked'] },
@@ -328,7 +331,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
     const { id } = req.params as { id: string };
 
     const shipment = await prisma.shipment.findFirst({
-      where: { id, archived: false },
+      where: { id, orgId: req.orgId!, archived: false },
       include: {
         customer: true,
         origin: true,
@@ -404,7 +407,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
       flaggedByName: z.string(),
     }).parse(req.body);
 
-    const result = await warehouseService.flagShipment(id, body.flaggedBy, body.flaggedByName, body.reason);
+    const result = await warehouseService.flagShipment(id, req.orgId!, body.flaggedBy, body.flaggedByName, body.reason);
     if (!result.success) {
       reply.code(404);
       return { data: null, error: result.error };
@@ -425,7 +428,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { flagId } = req.params as { shipmentId: string; flagId: string };
     const body = z.object({ resolvedBy: z.string() }).parse(req.body);
-    const result = await warehouseService.resolveFlag(flagId, body.resolvedBy);
+    const result = await warehouseService.resolveFlag(flagId, req.orgId!, body.resolvedBy);
     if (!result.success) {
       reply.code(404);
       return { data: null, error: result.error };
@@ -453,7 +456,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { barcode } = req.query as { barcode: string };
-    const result = await warehouseService.lookupDevice(barcode);
+    const result = await warehouseService.lookupDevice(barcode, req.orgId!);
     if (!result.success) {
       reply.code(404);
       return { data: null, error: result.error };
@@ -485,9 +488,13 @@ export async function warehouseRoutes(server: FastifyInstance) {
       trackableUnitId: z.string().optional(),
     }).parse(req.body);
 
-    const result = await warehouseService.assignDeviceToShipment(id, body.deviceId, body.trackableUnitId);
+    const result = await warehouseService.assignDeviceToShipment(id, body.deviceId, req.orgId!, body.trackableUnitId);
+    if (!result.success) {
+      reply.code(404);
+      return { data: null, error: result.error };
+    }
     reply.code(201);
-    return { data: result.success ? result.data : null, error: null };
+    return { data: result.data, error: null };
   });
 
   /**
@@ -501,7 +508,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { id, deviceId } = req.params as { id: string; deviceId: string };
-    await warehouseService.removeDeviceFromShipment(id, deviceId);
+    await warehouseService.removeDeviceFromShipment(id, deviceId, req.orgId!);
     return { data: { removed: true }, error: null };
   });
 
@@ -539,7 +546,11 @@ export async function warehouseRoutes(server: FastifyInstance) {
       notes: z.string().optional(),
     }).parse(req.body);
 
-    const result = await warehouseService.addAccessory(id, body);
+    const result = await warehouseService.addAccessory(id, req.orgId!, body);
+    if (!result.success) {
+      reply.code(404);
+      return { data: null, error: result.error };
+    }
     reply.code(201);
     return { data: result.data, error: null };
   });
@@ -555,7 +566,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { accessoryId } = req.params as { id: string; accessoryId: string };
-    await warehouseService.removeAccessory(accessoryId);
+    await warehouseService.removeAccessory(accessoryId, req.orgId!);
     return { data: { removed: true }, error: null };
   });
 
@@ -580,7 +591,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { id } = req.params as { id: string };
     const { launchedBy } = z.object({ launchedBy: z.string() }).parse(req.body);
-    const result = await warehouseService.launchShipment(id, launchedBy);
+    const result = await warehouseService.launchShipment(id, req.orgId!, launchedBy);
     if (!result.success) {
       reply.code(result.error.includes('not found') ? 404 : 400);
       return { data: null, error: result.error };
@@ -690,6 +701,8 @@ export async function warehouseRoutes(server: FastifyInstance) {
           { barcode },
           { identifier: barcode },
         ],
+        // TrackableUnit has no orgId of its own; tenancy flows through the order
+        order: { orgId: req.orgId! },
       },
       include: {
         order: { select: { id: true, orderNumber: true } },
@@ -716,9 +729,9 @@ export async function warehouseRoutes(server: FastifyInstance) {
       tags: ['Warehouse'],
       summary: 'List locations for warehouse selection',
     },
-  }, async (_req: FastifyRequest, _reply: FastifyReply) => {
+  }, async (req: FastifyRequest, _reply: FastifyReply) => {
     const locations = await prisma.location.findMany({
-      where: { archived: false },
+      where: { orgId: req.orgId!, archived: false },
       select: { id: true, name: true, city: true, state: true, country: true },
       orderBy: { name: 'asc' },
       take: 500,
@@ -830,7 +843,8 @@ export async function warehouseRoutes(server: FastifyInstance) {
     const query = req.query as { userId?: string; method?: string; limit?: string };
     const limit = Math.min(parseInt(query.limit || '100'), 500);
 
-    const where: any = {};
+    // LoginAuditLog has no orgId of its own; tenancy flows through the user
+    const where: any = { user: { organizationId: req.orgId! } };
     if (query.userId) where.userId = query.userId;
     if (query.method) where.method = query.method;
 
@@ -861,7 +875,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
     const { userId } = req.params as { userId: string };
 
     await prisma.magicLink.updateMany({
-      where: { userId, active: true },
+      where: { userId, active: true, user: { organizationId: req.orgId! } },
       data: { active: false },
     });
 
@@ -884,6 +898,7 @@ export async function warehouseRoutes(server: FastifyInstance) {
     const twoDaysAgo = new Date(Date.now() - 2 * 86400000);
 
     const where: any = {
+      orgId: req.orgId!,
       archived: false,
       status: { in: ['draft', 'ready', 'picked'] },
       launchedAt: null,

--- a/backend/src/services/WarehouseService.ts
+++ b/backend/src/services/WarehouseService.ts
@@ -53,17 +53,19 @@ export class WarehouseService {
 
   async generateMagicLink(
     userId: string,
+    orgId: string,
     expiresInDays?: number,
   ): Promise<{ success: true; data: MagicLinkResult } | { success: false; error: string }> {
-    // Check magic links are enabled
-    const org = await this.prisma.organization.findFirst();
+    // Check magic links are enabled for the caller's organization
+    const org = await this.prisma.organization.findUnique({ where: { id: orgId } });
     if (!org?.magicLinksEnabled) {
       return { success: false, error: 'Magic links are disabled for this organization' };
     }
 
-    // Verify user exists
+    // Verify user exists and belongs to the caller's organization.
+    // Cross-tenant target reads as "not found" so existence stays opaque.
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
-    if (!user || !user.active) {
+    if (!user || !user.active || user.organizationId !== orgId) {
       return { success: false, error: 'User not found or inactive' };
     }
 
@@ -239,12 +241,13 @@ export class WarehouseService {
 
   async flagShipment(
     shipmentId: string,
+    orgId: string,
     flaggedBy: string,
     flaggedByName: string,
     reason: string,
   ): Promise<{ success: true; data: any } | { success: false; error: string }> {
     const shipment = await this.prisma.shipment.findFirst({
-      where: { id: shipmentId, archived: false },
+      where: { id: shipmentId, orgId, archived: false },
     });
     if (!shipment) {
       return { success: false, error: 'Shipment not found' };
@@ -259,9 +262,12 @@ export class WarehouseService {
 
   async resolveFlag(
     flagId: string,
+    orgId: string,
     resolvedBy: string,
   ): Promise<{ success: true; data: any } | { success: false; error: string }> {
-    const flag = await this.prisma.shipmentFlag.findUnique({ where: { id: flagId } });
+    const flag = await this.prisma.shipmentFlag.findFirst({
+      where: { id: flagId, shipment: { orgId } },
+    });
     if (!flag) {
       return { success: false, error: 'Flag not found' };
     }
@@ -276,10 +282,11 @@ export class WarehouseService {
 
   async launchShipment(
     shipmentId: string,
+    orgId: string,
     launchedBy: string,
   ): Promise<{ success: true; data: any } | { success: false; error: string }> {
     const shipment = await this.prisma.shipment.findFirst({
-      where: { id: shipmentId, archived: false },
+      where: { id: shipmentId, orgId, archived: false },
     });
     if (!shipment) {
       return { success: false, error: 'Shipment not found' };
@@ -309,6 +316,7 @@ export class WarehouseService {
 
   async lookupDevice(
     barcode: string,
+    orgId: string,
   ): Promise<{ success: true; data: any } | { success: false; error: string }> {
     const device = await this.prisma.device.findFirst({
       where: {
@@ -318,6 +326,7 @@ export class WarehouseService {
           { name: barcode },
         ],
         status: 'active',
+        orgId,
       },
       include: {
         assignments: {
@@ -347,8 +356,26 @@ export class WarehouseService {
   async assignDeviceToShipment(
     shipmentId: string,
     deviceId: string,
+    orgId: string,
     trackableUnitId?: string,
   ): Promise<{ success: true; data: any } | { success: false; error: string }> {
+    // Both sides of the assignment must belong to the caller's org;
+    // cross-tenant ids read as "not found" so existence stays opaque.
+    const shipment = await this.prisma.shipment.findFirst({
+      where: { id: shipmentId, orgId, archived: false },
+      select: { id: true },
+    });
+    if (!shipment) {
+      return { success: false, error: 'Shipment not found' };
+    }
+    const device = await this.prisma.device.findFirst({
+      where: { id: deviceId, orgId },
+      select: { id: true },
+    });
+    if (!device) {
+      return { success: false, error: 'Device not found' };
+    }
+
     // Deactivate existing assignments
     await this.prisma.deviceAssignment.updateMany({
       where: { deviceId, active: true },
@@ -369,9 +396,10 @@ export class WarehouseService {
   async removeDeviceFromShipment(
     shipmentId: string,
     deviceId: string,
+    orgId: string,
   ): Promise<{ success: true } | { success: false; error: string }> {
     await this.prisma.deviceAssignment.updateMany({
-      where: { deviceId, shipmentId, active: true },
+      where: { deviceId, shipmentId, active: true, shipment: { orgId } },
       data: { active: false, unassignedAt: new Date() },
     });
     return { success: true };
@@ -381,6 +409,7 @@ export class WarehouseService {
 
   async addAccessory(
     shipmentId: string,
+    orgId: string,
     data: {
       accessoryType: string;
       alias?: string;
@@ -389,7 +418,14 @@ export class WarehouseService {
       deviceId?: string;
       notes?: string;
     },
-  ): Promise<{ success: true; data: any }> {
+  ): Promise<{ success: true; data: any } | { success: false; error: string }> {
+    const shipment = await this.prisma.shipment.findFirst({
+      where: { id: shipmentId, orgId, archived: false },
+      select: { id: true },
+    });
+    if (!shipment) {
+      return { success: false, error: 'Shipment not found' };
+    }
     const accessory = await this.prisma.shipmentAccessory.create({
       data: {
         shipmentId,
@@ -406,8 +442,11 @@ export class WarehouseService {
 
   async removeAccessory(
     accessoryId: string,
+    orgId: string,
   ): Promise<{ success: true }> {
-    await this.prisma.shipmentAccessory.delete({ where: { id: accessoryId } });
+    await this.prisma.shipmentAccessory.deleteMany({
+      where: { id: accessoryId, shipment: { orgId } },
+    });
     return { success: true };
   }
 

--- a/frontend/src/authFetch.ts
+++ b/frontend/src/authFetch.ts
@@ -34,7 +34,14 @@ function requestAlreadyHasAuth(init: RequestInit | undefined, input: RequestInfo
 function isPortalRoute(url: string): boolean {
   // WMS admin endpoints share the /api/v1/warehouse/ prefix with the PWA but
   // require the main TMS JWT. Keep them on the standard auth path.
-  if (url.includes('/api/v1/warehouse/zones') || url.includes('/api/v1/warehouse/bins')) {
+  // magic-link/generate and the login audit log are admin-app actions
+  // (VNextSettings), not PWA ones; generate requires auth as of #130.
+  if (
+    url.includes('/api/v1/warehouse/zones') ||
+    url.includes('/api/v1/warehouse/bins') ||
+    url.includes('/api/v1/warehouse/auth/magic-link/generate') ||
+    url.includes('/api/v1/warehouse/audit')
+  ) {
     return false;
   }
   // Portals manage their own tokens — don't inject the main TMS token into them.


### PR DESCRIPTION
Closes #130.

The reported bug was the locations endpoint, but the audit the issue asked for found the whole file leaking, plus one worse thing.

**Tenancy fixes** (cross-org data no longer visible, cross-org ids read as 404):
- `GET /warehouse/locations`: org-filtered (was returning every tenant's locations)
- Shipments list, detail, and archive: org-filtered
- Trackable unit lookup: scoped through the order's org (TrackableUnit has no orgId)
- Login audit log and magic-link revoke: scoped through the user's org
- User preferences: could update any user in any org; now scoped + 404
- `WarehouseService` methods all take the caller's orgId: flag/resolve/launch, device lookup/assign/remove, accessories. Device assignment now verifies both the shipment and the device belong to the caller before writing.
- `generateMagicLink` also loses its `organization.findFirst()` (the forbidden pattern) and refuses cross-org target users

**Auth fix:** `POST /warehouse/auth/magic-link/generate` was in the unauthenticated path set (the TODO in the file admitted it). Anyone who could reach the API could mint a login link for any user id. It now requires a JWT like every other admin action, and `authFetch` carve-outs make the admin settings page send its token there and to the audit log (whose widget was silently 401ing before).

**Tests:** 57 WarehouseService tests pass including a new org-scoping block (cross-org user/shipment/device refusal, scoped where-clauses). Full backend suite: 164 suites, 1651 tests green. `tsc --noEmit` adds no errors over main (main has 21 pre-existing).

**Noted, not fixed here:** the warehouse PWA never attaches its session JWT to requests, so its operational calls 401 against the auth that's already on these routes; that's a client-side bug I'll file separately. The locations endpoint also remains unpaginated (take: 500), acceptable for an org-scoped picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)