### PR TITLE
Org-scope Quality Centre routes via req.orgId, drop organization.findFirst() (#132)

### DIFF
--- a/backend/src/__tests__/routes/qualityCentre.orgScope.test.ts
+++ b/backend/src/__tests__/routes/qualityCentre.orgScope.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Org-scoping spot checks for the Quality Centre routes (#132).
+ *
+ * The route plugin previously resolved its org via
+ * `prisma.organization.findFirst()`, which silently picks the first org
+ * for every caller. These tests register the real plugin against a
+ * mocked prisma whose finders behave org-aware (a row is only returned
+ * when the where clause carries the matching orgId), then inject
+ * requests as org-a and org-b and assert cross-tenant ids read as 404.
+ */
+
+import Fastify from 'fastify';
+
+jest.mock('../../di/index.js', () => {
+  const stub = {
+    dispatch: jest.fn().mockResolvedValue({ id: 'result-1' }),
+    findByEntity: jest.fn().mockResolvedValue([]),
+    save: jest.fn(),
+    create: jest.fn(),
+  };
+  return {
+    container: { resolve: jest.fn(() => stub) },
+    TOKENS: new Proxy({}, { get: (_t, prop) => Symbol.for(String(prop)) }),
+  };
+});
+
+import { qualityCentreRoutes } from '../../routes/qualityCentre.js';
+
+// Org-aware finder: mimics the DB by returning a row only when the where
+// clause's orgId (direct or via the audit relation) matches the row.
+function orgAwareFindFirst(rows: Array<Record<string, any>>) {
+  return jest.fn().mockImplementation(({ where }: any) =>
+    Promise.resolve(
+      rows.find((r) =>
+        (!where.id || r.id === where.id) &&
+        (!where.orgId || r.orgId === where.orgId) &&
+        (!where.audit?.orgId || r.auditOrgId === where.audit.orgId),
+      ) ?? null,
+    ),
+  );
+}
+
+function buildPrisma() {
+  return {
+    cAPAFollowUp: {
+      findFirst: orgAwareFindFirst([
+        { id: 'fu-a', orgId: 'org-a', reviewType: 'day_30' },
+        { id: 'fu-b', orgId: 'org-b', reviewType: 'day_60' },
+      ]),
+    },
+    sOPChecklist: {
+      findFirst: orgAwareFindFirst([
+        { id: 'cl-a', orgId: 'org-a', title: 'GDP Annual Review' },
+        { id: 'cl-b', orgId: 'org-b', title: 'Cold Chain SOP Check' },
+      ]),
+    },
+    sOPAudit: {
+      findFirst: orgAwareFindFirst([
+        { id: 'audit-a', orgId: 'org-a', status: 'in_progress' },
+        { id: 'audit-b', orgId: 'org-b', status: 'in_progress' },
+      ]),
+    },
+    sOPAuditResponse: {
+      findFirst: orgAwareFindFirst([
+        { id: 'resp-a', auditOrgId: 'org-a', result: 'pass' },
+        { id: 'resp-b', auditOrgId: 'org-b', result: 'pass' },
+      ]),
+      update: jest.fn().mockImplementation(({ where }: any) =>
+        Promise.resolve({ id: where.id, result: 'pass' }),
+      ),
+    },
+  } as any;
+}
+
+async function buildApp() {
+  const app = Fastify();
+  app.decorate('prisma', buildPrisma());
+  // Simulate the authenticated principal's tenant. registerOrgScope's
+  // hook is idempotent (skips when req.orgId is already set), so setting
+  // it here mirrors production where the JWT drives the value.
+  app.addHook('preHandler', async (req) => {
+    (req as any).orgId = (req.headers['x-test-org'] as string) || 'org-a';
+  });
+  await app.register(qualityCentreRoutes);
+  return app;
+}
+
+describe('Quality Centre org scoping', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>;
+
+  beforeEach(async () => {
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  const crossTenantCases: Array<[string, string]> = [
+    ['CAPA follow-up detail', '/api/v1/quality/capa-follow-ups/fu-b'],
+    ['SOP checklist detail', '/api/v1/quality/sop-checklists/cl-b'],
+    ['SOP audit detail', '/api/v1/quality/sop-audits/audit-b'],
+    ['SOP audit evidence list', '/api/v1/quality/sop-audits/audit-b/evidence'],
+  ];
+
+  it.each(crossTenantCases)(
+    '%s: org-a guessing an org-b id gets 404',
+    async (_name, url) => {
+      const res = await app.inject({ method: 'GET', url, headers: { 'x-test-org': 'org-a' } });
+      expect(res.statusCode).toBe(404);
+    },
+  );
+
+  it.each(crossTenantCases)(
+    '%s: the owning org can read its own row',
+    async (_name, url) => {
+      const ownUrl = url.replace(/-b(\/|$)/, '-a$1');
+      const res = await app.inject({ method: 'GET', url: ownUrl, headers: { 'x-test-org': 'org-a' } });
+      expect(res.statusCode).toBe(200);
+    },
+  );
+
+  it('audit response update: org-a cannot modify an org-b response', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/quality/sop-audits/audit-b/responses/resp-b',
+      headers: { 'x-test-org': 'org-a' },
+      payload: { notes: 'tampered' },
+    });
+    expect(res.statusCode).toBe(404);
+    expect((app as any).prisma.sOPAuditResponse.update).not.toHaveBeenCalled();
+  });
+
+  it('audit response update: the owning org can modify its own response', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/quality/sop-audits/audit-a/responses/resp-a',
+      headers: { 'x-test-org': 'org-a' },
+      payload: { notes: 'checked' },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/backend/src/routes/qualityCentre.ts
+++ b/backend/src/routes/qualityCentre.ts
@@ -6,6 +6,7 @@
  */
 
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { registerOrgScope } from '../auth/orgScopeMiddleware.js';
 import { randomUUID } from 'crypto';
 import { container, TOKENS } from '../di/index.js';
 import { ICommandBus } from '../commands/CommandBus.js';
@@ -20,10 +21,10 @@ import { COMPLETE_SOP_AUDIT } from '../commands/sopChecklists/CompleteSOPAuditCo
 export async function qualityCentreRoutes(server: FastifyInstance) {
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
 
-  const getOrgId = async () => {
-    const org = await server.prisma.organization.findFirst({ select: { id: true } });
-    return org?.id || 'default-org';
-  };
+  // Tenancy: org comes from the authenticated principal via the standard
+  // org-scope hook, never from organization.findFirst() (which silently
+  // picks the first org for every caller once a second org exists).
+  await registerOrgScope(server);
 
   // ─── Dashboard Stats ───────────────────────────────────────────────────────
 
@@ -42,8 +43,8 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
         },
       },
     },
-  }, async (_req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+  }, async (req: FastifyRequest, _reply: FastifyReply) => {
+    const orgId = req.orgId!;
     const now = new Date();
 
     // Issue stats
@@ -141,7 +142,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, _reply: FastifyReply) => {
     const { period = '30d', category } = req.query as { period?: string; category?: string };
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
     const now = new Date();
 
     let startDate: Date;
@@ -210,7 +211,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       sortOrder = 'desc',
       limit = 50,
     } = req.query as { dimensionType?: string; sortBy?: string; sortOrder?: string; limit?: number };
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
 
     const where: any = { orgId };
     if (dimensionType) where.dimensionType = dimensionType;
@@ -232,8 +233,8 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       summary: 'Rebuild quality issue summaries',
       description: 'Rebuilds all QualityIssueSummary rows from scratch. Use after data migration or corrections.',
     },
-  }, async (_req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+  }, async (req: FastifyRequest, _reply: FastifyReply) => {
+    const orgId = req.orgId!;
 
     // Import and invoke the projection rebuild
     const { QualityIssueSummaryProjection } = await import('../events/projections/QualityIssueSummaryProjection.js');
@@ -263,7 +264,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
     const { capaReportId, status, followUpType } = req.query as {
       capaReportId?: string; status?: string; followUpType?: string;
     };
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
 
     const where: any = { orgId };
     if (capaReportId) where.capaReportId = capaReportId;
@@ -294,8 +295,8 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { id } = req.params as { id: string };
-    const followUp = await server.prisma.cAPAFollowUp.findUnique({
-      where: { id },
+    const followUp = await server.prisma.cAPAFollowUp.findFirst({
+      where: { id, orgId: req.orgId! },
       include: {
         capaReport: { select: { reportNumber: true, title: true, status: true, issueId: true } },
       },
@@ -327,7 +328,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       },
     },
   }, async (req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
     const body = req.body as any;
 
     const result = await commandBus.dispatch({
@@ -366,7 +367,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       },
     },
   }, async (req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
     const { id } = req.params as { id: string };
     const body = req.body as any;
 
@@ -401,7 +402,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       },
     },
   }, async (req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
     const { capaReportId, assigneeId, assigneeName } = req.body as any;
 
     const capa = await server.prisma.cAPAReport.findFirst({
@@ -456,7 +457,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, _reply: FastifyReply) => {
     const { category, status } = req.query as { category?: string; status?: string };
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
 
     const where: any = { orgId };
     if (category) where.category = category;
@@ -487,8 +488,8 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { id } = req.params as { id: string };
-    const checklist = await server.prisma.sOPChecklist.findUnique({
-      where: { id },
+    const checklist = await server.prisma.sOPChecklist.findFirst({
+      where: { id, orgId: req.orgId! },
       include: {
         items: { orderBy: { sortOrder: 'asc' } },
         audits: {
@@ -538,7 +539,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       },
     },
   }, async (req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
     const body = req.body as any;
 
     const result = await commandBus.dispatch({
@@ -578,7 +579,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       },
     },
   }, async (req: FastifyRequest, reply: FastifyReply) => {
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
     const { id } = req.params as { id: string };
     const body = req.body as any;
 
@@ -617,7 +618,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, _reply: FastifyReply) => {
     const { checklistId, status } = req.query as { checklistId?: string; status?: string };
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
 
     const where: any = { orgId };
     if (checklistId) where.checklistId = checklistId;
@@ -647,8 +648,8 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { id } = req.params as { id: string };
-    const audit = await server.prisma.sOPAudit.findUnique({
-      where: { id },
+    const audit = await server.prisma.sOPAudit.findFirst({
+      where: { id, orgId: req.orgId! },
       include: {
         checklist: { include: { items: { orderBy: { sortOrder: 'asc' } } } },
         responses: true,
@@ -676,7 +677,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       },
     },
   }, async (req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
     const body = req.body as any;
 
     const result = await commandBus.dispatch({
@@ -726,7 +727,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       },
     },
   }, async (req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
     const { id } = req.params as { id: string };
     const body = req.body as any;
 
@@ -752,8 +753,8 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       summary: 'Carrier quality scorecard',
       description: 'Returns quality metrics per carrier: issue counts, CAPA rates, resolution times.',
     },
-  }, async (_req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+  }, async (req: FastifyRequest, _reply: FastifyReply) => {
+    const orgId = req.orgId!;
 
     const summaries = await server.prisma.qualityIssueSummary.findMany({
       where: { orgId, dimensionType: 'carrier' },
@@ -770,8 +771,8 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       summary: 'Lane quality analysis',
       description: 'Returns quality metrics per lane: issue frequency, common categories, problem severity.',
     },
-  }, async (_req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+  }, async (req: FastifyRequest, _reply: FastifyReply) => {
+    const orgId = req.orgId!;
 
     const summaries = await server.prisma.qualityIssueSummary.findMany({
       where: { orgId, dimensionType: 'lane' },
@@ -788,8 +789,8 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
       summary: 'CAPA effectiveness report',
       description: 'Returns CAPA reports with follow-up completion rates and effectiveness outcomes.',
     },
-  }, async (_req: FastifyRequest, _reply: FastifyReply) => {
-    const orgId = await getOrgId();
+  }, async (req: FastifyRequest, _reply: FastifyReply) => {
+    const orgId = req.orgId!;
 
     const capas = await server.prisma.cAPAReport.findMany({
       where: { orgId },
@@ -856,7 +857,7 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
     },
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { auditId } = req.params as { auditId: string };
-    const orgId = await getOrgId();
+    const orgId = req.orgId!;
 
     // Verify audit exists and belongs to org
     const audit = await server.prisma.sOPAudit.findFirst({
@@ -933,8 +934,16 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
         properties: { auditId: { type: 'string' } },
       },
     },
-  }, async (req: FastifyRequest, _reply: FastifyReply) => {
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { auditId } = req.params as { auditId: string };
+    const audit = await server.prisma.sOPAudit.findFirst({
+      where: { id: auditId, orgId: req.orgId! },
+      select: { id: true },
+    });
+    if (!audit) {
+      reply.code(404);
+      return { data: null, error: 'Audit not found' };
+    }
     const attachments = await attachmentRepo.findByEntity('sop_audit', auditId);
     return { data: attachments, error: null };
   });
@@ -967,8 +976,8 @@ export async function qualityCentreRoutes(server: FastifyInstance) {
     const { responseId } = req.params as { auditId: string; responseId: string };
     const body = req.body as any;
 
-    const existing = await server.prisma.sOPAuditResponse.findUnique({
-      where: { id: responseId },
+    const existing = await server.prisma.sOPAuditResponse.findFirst({
+      where: { id: responseId, audit: { orgId: req.orgId! } },
     });
     if (!existing) {
       reply.code(404);


### PR DESCRIPTION
Closes #132.

The headline fix: the plugin's local `getOrgId()` did `prisma.organization.findFirst()`, so every caller resolved to whichever org sorts first. It's replaced with the standard `registerOrgScope` hook and `req.orgId!` at all 18 call sites, matching every other authed plugin.

The audit the issue asked for found five endpoints with **no org scope at all**, readable or writable cross-tenant by id guess. All now return 404 for another org's ids:
- CAPA follow-up detail
- SOP checklist detail
- SOP audit detail
- SOP audit evidence list (verifies the audit's org before listing attachments)
- SOP audit response update (scoped through the audit's org; the write is refused before it happens)

**Tests:** new route-level suite registers the real plugin against an org-aware prisma double and injects as two orgs: cross-tenant 404s, own-org 200s, and the cross-tenant write never reaching `update` (10 tests). Full backend suite green; `tsc` unchanged vs main (21 pre-existing errors).

Worth noting for the Track 0 backlog rather than this PR: these route handlers still query prisma directly (a layering-rule violation across the whole file) and the list endpoints are unpaginated. Both pre-date this change and are better handled when the quality module is carved out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)