### PR TITLE
Raise pack-audit issues via CREATE_ISSUE after commit, repair orphans (#131)

### DIFF
--- a/backend/src/__tests__/commands/PackAuditCommands.test.ts
+++ b/backend/src/__tests__/commands/PackAuditCommands.test.ts
@@ -56,32 +56,36 @@ describe('RecordPackAuditCommand', () => {
     expect(result.events[0].type).toBe(EVENT_TYPES.PACK_AUDIT_RECORDED);
   });
 
-  it('returns verdict "warning" and creates an issue when variance exceeds tolerance but within 2x', async () => {
+  it('returns verdict "warning" and emits an enriched variance event, never a direct issue write', async () => {
     const tx = makeTx();
     const { bus } = mockEventBus();
     const handler = new RecordPackAuditCommandHandler(makePrisma(tx), bus);
 
     // Expected = 1200g, actual 1400g = +16.7% → 10 < 16.7 < 20 → warning
     const result = await handler.execute(
-      createTestCommand(RECORD_PACK_AUDIT, { packTaskId: 'pack-1', actualWeightGrams: 1400 }),
+      createTestCommand(RECORD_PACK_AUDIT, { packTaskId: 'pack-1', actualWeightGrams: 1400, notes: 'box felt heavy' }),
     );
 
     expect(result.success).toBe(true);
     expect(result.data?.verdict).toBe('warning');
-    expect(result.data?.issueId).toBe('issue-1');
-    expect(tx.issue.create).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        priority: 'medium',
-        category: 'quality',
-        sourceEntityType: 'pack_task',
-        sourceEntityId: 'pack-1',
-      }),
-    }));
+    // Issue creation moved after commit (PackAuditIssueHandler via CREATE_ISSUE):
+    // a direct write here bypassed the issue pipeline, so pack-audit issues
+    // never reached IssueReadModel or the triage board.
+    expect(result.data?.issueId).toBeNull();
+    expect(tx.issue.create).not.toHaveBeenCalled();
     const varianceEvent = result.events.find(e => e.type === EVENT_TYPES.PACK_AUDIT_VARIANCE_DETECTED);
     expect(varianceEvent).toBeDefined();
+    expect(varianceEvent!.payload).toEqual(expect.objectContaining({
+      packTaskId: 'pack-1',
+      verdict: 'warning',
+      expectedWeightGrams: 1200,
+      actualWeightGrams: 1400,
+      tolerance: 10,
+      notes: 'box felt heavy',
+    }));
   });
 
-  it('returns verdict "fail" and creates a high-priority issue beyond 2x tolerance', async () => {
+  it('returns verdict "fail" and emits the variance event, without a direct issue write', async () => {
     const tx = makeTx();
     const { bus } = mockEventBus();
     const handler = new RecordPackAuditCommandHandler(makePrisma(tx), bus);
@@ -93,9 +97,9 @@ describe('RecordPackAuditCommand', () => {
 
     expect(result.success).toBe(true);
     expect(result.data?.verdict).toBe('fail');
-    expect(tx.issue.create).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({ priority: 'high' }),
-    }));
+    expect(tx.issue.create).not.toHaveBeenCalled();
+    const varianceEvent = result.events.find(e => e.type === EVENT_TYPES.PACK_AUDIT_VARIANCE_DETECTED);
+    expect(varianceEvent!.payload).toEqual(expect.objectContaining({ verdict: 'fail' }));
   });
 
   it('handles negative variance (lighter than expected) symmetrically', async () => {

--- a/backend/src/__tests__/handlers/PackAuditIssueHandler.test.ts
+++ b/backend/src/__tests__/handlers/PackAuditIssueHandler.test.ts
@@ -1,0 +1,133 @@
+import { PackAuditIssueHandler, PACK_AUDIT_ISSUE_TYPE } from '../../events/handlers/PackAuditIssueHandler';
+import { CREATE_ISSUE } from '../../commands/issues/CreateIssueCommand';
+import { EVENT_TYPES } from '../../events/eventTypes';
+import { DomainEvent } from '../../events/DomainEvent';
+
+function makeEvent(overrides: Partial<DomainEvent> = {}): DomainEvent {
+  return {
+    id: 'evt-1',
+    type: EVENT_TYPES.PACK_AUDIT_VARIANCE_DETECTED,
+    schemaVersion: 1,
+    entityType: 'pack_audit',
+    entityId: 'audit-1',
+    orgId: 'org-1',
+    actorId: 'user-1',
+    occurredAt: new Date(),
+    payload: {
+      packTaskId: 'pack-1',
+      orderId: 'order-1',
+      verdict: 'warning',
+      weightVariancePercent: 16.7,
+      dimWeightVariancePercent: null,
+      expectedWeightGrams: 1200,
+      actualWeightGrams: 1400,
+      tolerance: 10,
+      notes: 'box felt heavy',
+    },
+    metadata: {},
+    ...overrides,
+  } as DomainEvent;
+}
+
+function makeDeps(opts: { openIssue?: { id: string } | null; dispatchResult?: any } = {}) {
+  const prisma = {
+    issue: { findFirst: jest.fn().mockResolvedValue(opts.openIssue ?? null) },
+    packAudit: { update: jest.fn().mockResolvedValue({}) },
+  } as any;
+  const commandBus = {
+    dispatch: jest.fn().mockResolvedValue(
+      opts.dispatchResult ?? { success: true, data: { id: 'issue-new', title: 't' } },
+    ),
+  } as any;
+  return { prisma, commandBus, handler: new PackAuditIssueHandler(prisma, commandBus) };
+}
+
+describe('PackAuditIssueHandler', () => {
+  it('raises an issue through CREATE_ISSUE with a valid category and links it to the audit', async () => {
+    const { prisma, commandBus, handler } = makeDeps();
+
+    await handler.handle(makeEvent());
+
+    expect(commandBus.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: CREATE_ISSUE,
+      orgId: 'org-1',
+      payload: expect.objectContaining({
+        category: 'exception',
+        issueType: PACK_AUDIT_ISSUE_TYPE,
+        priority: 'medium',
+        sourceEntityType: 'pack_task',
+        sourceEntityId: 'pack-1',
+        sourceEventId: 'evt-1',
+      }),
+    }));
+    expect(prisma.packAudit.update).toHaveBeenCalledWith({
+      where: { id: 'audit-1' },
+      data: { issueId: 'issue-new' },
+    });
+  });
+
+  it('maps a fail verdict to high priority', async () => {
+    const { commandBus, handler } = makeDeps();
+
+    await handler.handle(makeEvent({ payload: { ...makeEvent().payload as any, verdict: 'fail' } }));
+
+    expect(commandBus.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({ priority: 'high' }),
+    }));
+  });
+
+  it('includes the variance detail and auditor notes in the description', async () => {
+    const { commandBus, handler } = makeDeps();
+
+    await handler.handle(makeEvent());
+
+    const payload = commandBus.dispatch.mock.calls[0][0].payload;
+    expect(payload.description).toContain('Expected 1200g, actual 1400g');
+    expect(payload.description).toContain('box felt heavy');
+  });
+
+  it('reuses an existing open issue for the same pack task instead of duplicating', async () => {
+    const { prisma, commandBus, handler } = makeDeps({ openIssue: { id: 'issue-open' } });
+
+    await handler.handle(makeEvent());
+
+    expect(commandBus.dispatch).not.toHaveBeenCalled();
+    expect(prisma.packAudit.update).toHaveBeenCalledWith({
+      where: { id: 'audit-1' },
+      data: { issueId: 'issue-open' },
+    });
+    // Dedup lookup is scoped to the tenant and the (issueType, source entity) pair
+    expect(prisma.issue.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        orgId: 'org-1',
+        issueType: PACK_AUDIT_ISSUE_TYPE,
+        sourceEntityType: 'pack_task',
+        sourceEntityId: 'pack-1',
+      }),
+    }));
+  });
+
+  it('does not link the audit when issue creation fails', async () => {
+    const { prisma, handler } = makeDeps({ dispatchResult: { success: false, error: 'boom' } });
+
+    await handler.handle(makeEvent());
+
+    expect(prisma.packAudit.update).not.toHaveBeenCalled();
+  });
+
+  it('ignores events without a packTaskId', async () => {
+    const { commandBus, prisma, handler } = makeDeps();
+
+    await handler.handle(makeEvent({ payload: { verdict: 'warning' } }));
+
+    expect(commandBus.dispatch).not.toHaveBeenCalled();
+    expect(prisma.packAudit.update).not.toHaveBeenCalled();
+  });
+
+  it('never throws out of handle when prisma fails (edge swallows, logs)', async () => {
+    const { prisma, handler } = makeDeps();
+    prisma.issue.findFirst.mockRejectedValue(new Error('db down'));
+
+    await expect(handler.handle(makeEvent())).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/commands/packAudit/RecordPackAuditCommand.ts
+++ b/backend/src/commands/packAudit/RecordPackAuditCommand.ts
@@ -127,27 +127,13 @@ export class RecordPackAuditCommandHandler extends BaseCommandHandler<
 
     const verdict = verdictFor(weightVariancePercent, tolerance);
 
-    let issueId: string | null = null;
-    if (verdict !== 'pass') {
-      const title = verdict === 'fail'
-        ? `Pack audit failure on PackTask ${packTask.id.slice(0, 8)}: ${weightVariancePercent.toFixed(1)}% weight variance`
-        : `Pack audit warning on PackTask ${packTask.id.slice(0, 8)}: ${weightVariancePercent.toFixed(1)}% weight variance`;
-      const issue = await tx.issue.create({
-        data: {
-          orgId: command.orgId,
-          title,
-          description: `Expected ${expectedWeightGrams}g, actual ${p.actualWeightGrams}g (tolerance ±${tolerance}%).` +
-            (dimWeightVariancePercent != null ? ` Dim weight variance ${dimWeightVariancePercent.toFixed(1)}%.` : '') +
-            (p.notes ? `\n\nAuditor notes: ${p.notes}` : ''),
-          priority: verdict === 'fail' ? 'high' : 'medium',
-          category: 'quality',
-          sourceEntityType: 'pack_task',
-          sourceEntityId: packTask.id,
-          status: 'open',
-        },
-      });
-      issueId = issue.id;
-    }
+    // BUSINESS RULE: variance issues are raised AFTER commit by
+    // PackAuditIssueHandler consuming pack.audit_variance_detected, via the
+    // CREATE_ISSUE command — never by a direct issue write here. A direct
+    // write bypasses the issue pipeline (no issue.created event), so the
+    // issue never reaches IssueReadModel or the triage board. The handler
+    // links the issue back onto PackAudit.issueId once created.
+    const issueId: string | null = null;
 
     const audit = await tx.packAudit.create({
       data: {
@@ -199,7 +185,11 @@ export class RecordPackAuditCommandHandler extends BaseCommandHandler<
           orderId: packTask.orderId,
           verdict,
           weightVariancePercent: Number(weightVariancePercent.toFixed(2)),
-          issueId,
+          dimWeightVariancePercent: dimWeightVariancePercent != null ? Number(dimWeightVariancePercent.toFixed(2)) : null,
+          expectedWeightGrams,
+          actualWeightGrams: p.actualWeightGrams,
+          tolerance,
+          notes: p.notes ?? null,
         },
       }));
     }

--- a/backend/src/events/handlers/PackAuditIssueHandler.ts
+++ b/backend/src/events/handlers/PackAuditIssueHandler.ts
@@ -1,0 +1,122 @@
+/**
+ * PackAuditIssueHandler
+ *
+ * Raises a triage issue for pack-audit variances (warning/fail verdicts)
+ * through the sanctioned CREATE_ISSUE command path, then links the issue
+ * back onto PackAudit.issueId so the admin list can jump straight to it.
+ *
+ * Why a handler and not the command: RecordPackAuditCommand used to write
+ * the issue directly inside its transaction, which bypassed the issue
+ * pipeline (no issue.created event), so pack-audit issues never reached
+ * IssueReadModel or the triage board. Issue writes go through the command
+ * bus, after commit (see the issues domain rule).
+ *
+ * Dedup mirrors the issue engine's rule: one open issue per
+ * (issueType, source entity). A repeat variance on the same pack task
+ * links to the existing open issue instead of raising a duplicate.
+ *
+ * NOTE for Track 0 Phase 0 (#133): once the issue-type registry accepts
+ * non-shipment sources, this handler collapses into a registry entry and
+ * the engine takes over. Until then it is the one sanctioned WMS issue
+ * raiser.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { DomainEvent } from '../DomainEvent.js';
+import { IEventHandler } from '../IEventHandler.js';
+import { SubscribeOptions } from '../IEventBus.js';
+import { ICommandBus } from '../../commands/CommandBus.js';
+import { CREATE_ISSUE } from '../../commands/issues/CreateIssueCommand.js';
+import { EVENT_TYPES } from '../eventTypes.js';
+import crypto from 'crypto';
+
+export const PACK_AUDIT_ISSUE_TYPE = 'pack_audit_variance';
+
+export class PackAuditIssueHandler implements IEventHandler {
+  readonly name = 'handler.pack_audit_issue';
+  readonly eventPatterns = [EVENT_TYPES.PACK_AUDIT_VARIANCE_DETECTED];
+  readonly options: SubscribeOptions = {
+    concurrency: 1,
+    priority: 15,
+  };
+
+  constructor(
+    private prisma: PrismaClient,
+    private commandBus: ICommandBus,
+  ) {}
+
+  async handle(event: DomainEvent): Promise<void> {
+    try {
+      const p = event.payload as Record<string, any>;
+      const packTaskId = p?.packTaskId as string | undefined;
+      const verdict = p?.verdict as string | undefined;
+      const auditId = event.entityId;
+      if (!packTaskId || !verdict || verdict === 'pass') return;
+
+      const issueId = await this.findOrCreateIssue(event, packTaskId, verdict, p);
+      if (!issueId) return;
+
+      await this.prisma.packAudit.update({
+        where: { id: auditId },
+        data: { issueId },
+      });
+    } catch (err) {
+      console.error('[PackAuditIssueHandler] Failed:', (err as Error).message);
+    }
+  }
+
+  private async findOrCreateIssue(
+    event: DomainEvent,
+    packTaskId: string,
+    verdict: string,
+    p: Record<string, any>,
+  ): Promise<string | null> {
+    // One open issue per (issueType, source entity), same as the engine's
+    // dedup rule: a repeat variance escalates attention on the existing
+    // issue rather than flooding the board.
+    const open = await this.prisma.issue.findFirst({
+      where: {
+        orgId: event.orgId,
+        issueType: PACK_AUDIT_ISSUE_TYPE,
+        sourceEntityType: 'pack_task',
+        sourceEntityId: packTaskId,
+        status: { notIn: ['resolved', 'closed'] },
+      },
+      select: { id: true },
+    });
+    if (open) return open.id;
+
+    const variance = Number(p.weightVariancePercent ?? 0);
+    const title = verdict === 'fail'
+      ? `Pack audit failure on PackTask ${packTaskId.slice(0, 8)}: ${variance.toFixed(1)}% weight variance`
+      : `Pack audit warning on PackTask ${packTaskId.slice(0, 8)}: ${variance.toFixed(1)}% weight variance`;
+    const description =
+      `Expected ${p.expectedWeightGrams}g, actual ${p.actualWeightGrams}g (tolerance ±${p.tolerance}%).` +
+      (p.dimWeightVariancePercent != null ? ` Dim weight variance ${Number(p.dimWeightVariancePercent).toFixed(1)}%.` : '') +
+      (p.notes ? `\n\nAuditor notes: ${p.notes}` : '');
+
+    const result = await this.commandBus.dispatch({
+      type: CREATE_ISSUE,
+      orgId: event.orgId,
+      actorId: 'pack-audit-monitor',
+      payload: {
+        title,
+        description,
+        priority: verdict === 'fail' ? 'high' : 'medium',
+        category: 'exception',
+        issueType: PACK_AUDIT_ISSUE_TYPE,
+        latched: false,
+        sourceEntityType: 'pack_task',
+        sourceEntityId: packTaskId,
+        sourceEventId: event.id,
+      },
+      metadata: { correlationId: crypto.randomUUID(), source: 'pack-audit-issue-handler' },
+    });
+
+    if (!result.success) {
+      console.warn(`[PackAuditIssueHandler] Failed to create issue: ${result.error}`);
+      return null;
+    }
+    return (result.data as { id: string } | undefined)?.id ?? null;
+  }
+}

--- a/backend/src/events/registerHandlers.ts
+++ b/backend/src/events/registerHandlers.ts
@@ -52,6 +52,7 @@ import { CarrierTrackingHandler } from './handlers/CarrierTrackingHandler.js';
 import { CarrierArchivalNotificationHandler } from './handlers/CarrierArchivalNotificationHandler.js';
 import { MarginAlertHandler } from './handlers/MarginAlertHandler.js';
 import { AutoReplenishmentHandler } from './handlers/AutoReplenishmentHandler.js';
+import { PackAuditIssueHandler } from './handlers/PackAuditIssueHandler.js';
 
 /** Read concurrency from env with a default */
 function envInt(key: string, fallback: number): number {
@@ -170,6 +171,12 @@ export async function registerEventHandlers(
   // WMS: auto-replenishment - reacts to pick line completion / inventory adjustments and fires CHECK_REPLENISHMENT
   if (commandBus) {
     handlers.push(new AutoReplenishmentHandler(prisma, commandBus));
+  }
+
+  // WMS: pack-audit variances raise triage issues through CREATE_ISSUE
+  // (after commit), then link the issue back onto PackAudit.issueId
+  if (commandBus) {
+    handlers.push(new PackAuditIssueHandler(prisma, commandBus));
   }
 
   // Deterministic Issue Engine: maps shipment-exception trigger/recovery events

--- a/backend/src/scripts/fix-pack-audit-issues.ts
+++ b/backend/src/scripts/fix-pack-audit-issues.ts
@@ -1,0 +1,54 @@
+/**
+ * One-off repair for pack-audit issues created before #131.
+ *
+ * RecordPackAuditCommand used to write issues directly with
+ * category: 'quality' — not a valid category (exception | delay | damage |
+ * compliance | other), so those issues failed every category filter, and
+ * because no issue.created event fired they never reached IssueReadModel
+ * or the triage board.
+ *
+ * This script repairs the rows in place: valid category, the issueType the
+ * new PackAuditIssueHandler stamps, and a lastActivityAt so triage ranking
+ * has something to sort on. Idempotent — the where clause matches nothing
+ * on a second run.
+ *
+ * Run afterwards to materialise them into the read model:
+ *   npx tsx backend/src/scripts/backfill-read-models.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const orphans = await prisma.issue.findMany({
+    where: { sourceEntityType: 'pack_task', category: 'quality' },
+    select: { id: true, orgId: true, createdAt: true },
+  });
+
+  if (orphans.length === 0) {
+    console.log('No orphaned pack-audit issues found — nothing to repair.');
+    return;
+  }
+
+  for (const issue of orphans) {
+    await prisma.issue.update({
+      where: { id: issue.id },
+      data: {
+        category: 'exception',
+        issueType: 'pack_audit_variance',
+        lastActivityAt: issue.createdAt,
+      },
+    });
+  }
+
+  console.log(`Repaired ${orphans.length} pack-audit issue(s).`);
+  console.log('Now run: npx tsx backend/src/scripts/backfill-read-models.ts');
+}
+
+main()
+  .catch((err) => {
+    console.error('Repair failed:', err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/docs/DOMAIN_BEHAVIOURS.md
+++ b/docs/DOMAIN_BEHAVIOURS.md
@@ -2142,14 +2142,14 @@ Default tolerance is 10%, overridable per-audit via `weightTolerancePercent` on 
 Dim-weight is calculated only when an audit links to a `CartonCatalogue` (expected dims) AND the caller supplies all three actual dims. Formula is the industry standard `(L × W × H cm) / 5000 = kg`. The result is stored as a separate `dimWeightVariancePercent` column; verdict today is driven only by the scale weight, but the dim-weight delta is surfaced in UI so ops can investigate.
 
 ### Issue auto-creation
-When verdict is `warning` or `fail`, an `Issue` is created inline within the same transaction (not via `CREATE_ISSUE` dispatch, to keep the audit + issue atomic). The issue uses `category: 'quality'`, `sourceEntityType: 'pack_task'`, `sourceEntityId: packTask.id` so the triage kanban and the pack task detail page both see it.
+When verdict is `warning` or `fail`, `PackAuditIssueHandler` (subscribed to `pack.audit_variance_detected`) dispatches `CREATE_ISSUE` after commit with `category: 'exception'`, `issueType: 'pack_audit_variance'`, `sourceEntityType: 'pack_task'`, then links the created issue back onto `PackAudit.issueId`. Dedup follows the engine rule: one open issue per (issueType, pack task); a repeat variance links to the existing open issue. The previous behaviour (inline `issue.create` in the command's transaction with the invalid `category: 'quality'`) bypassed the issue pipeline, so those issues never fired `issue.created` and never reached `IssueReadModel` or the triage board; `scripts/fix-pack-audit-issues.ts` repairs historical rows, followed by the read-model backfill.
 
 ### Events
-- `pack.audit_recorded` - every audit, payload includes verdict, variances, expected/actual weight, tolerance, issueId (nullable)
-- `pack.audit_variance_detected` - only warning/fail, payload includes verdict, weight variance, issueId
+- `pack.audit_recorded` - every audit, payload includes verdict, variances, expected/actual weight, tolerance, issueId (null at emit time; linked after commit)
+- `pack.audit_variance_detected` - only warning/fail, payload includes verdict, both variances, expected/actual weight, tolerance and auditor notes (what the issue handler needs to build the issue)
 
 ### Commands
-- `RECORD_PACK_AUDIT` - single atomic operation: compute expected (unless override supplied), compute variance, assign verdict, create issue if non-pass, persist audit row, emit events
+- `RECORD_PACK_AUDIT` - compute expected (unless override supplied), compute variance, assign verdict, persist audit row, emit events. Issue creation happens after commit via `PackAuditIssueHandler` → `CREATE_ISSUE`
 
 ### API
 | Method | Endpoint | Purpose |

--- a/roadmap.md
+++ b/roadmap.md
@@ -498,7 +498,7 @@ Bolt-on WMS extending the TMS's TrackableUnit/CargoScan/Location models. Full sp
 
 - **WMS v1 Gap Close-Out** ✅
   - Wave auto-release worker - `WaveAutoReleaseService` + pg-boss cron (`wave-auto-release`, default every 5 min). Templates with `autoRelease=true` and a `releaseSchedule` (HH:MM or simple cron) + `cutoffTime` fallback fire `APPLY_WAVE_TEMPLATE` when due. `lastAutoReleasedAt` dedup stamp prevents re-firing within a 12h window. Configurable via `WAVE_AUTO_RELEASE_CRON`
-  - Pack audit events (`pack.audit_recorded`, `pack.audit_variance_detected`) now subscribed by `CustomerWebhookHandler` via pack task → order → customer resolver so third-party integrations receive them as webhooks (inline issue creation in the command stays for atomicity)
+  - Pack audit events (`pack.audit_recorded`, `pack.audit_variance_detected`) now subscribed by `CustomerWebhookHandler` via pack task → order → customer resolver so third-party integrations receive them as webhooks (issue creation moved after commit via `PackAuditIssueHandler` → `CREATE_ISSUE` in #131, so the issues reach the read model and triage board)
   - Receiving Appointments admin UI at `/wms/receiving-appointments` - date-filterable list with one-click check-in and cancel; new appointment form with carrier, trailer, seal, ASN reference, dock bin picker. Exposes `/api/v1/receiving/appointments/:id/check-in` and `/cancel` endpoints
   - Receiving Appointments mobile flow at `/warehouse/appointments` - today's arrivals with status chips and single-tap check-in, accessible from the bottom nav
   - Fixes from audit gaps 1-3: WaveTemplate `zonePickMode` wired end-to-end, `/cycle-counts/:id` `params` schema added, `ManifestUpload.location` relation + FK migration


### PR DESCRIPTION
Closes #131.

**The bug:** `RecordPackAuditCommand` created issues with a raw `tx.issue.create` inside its transaction, using `category: 'quality'` (not a valid category). No `issue.created` event ever fired, so pack-audit issues never reached `IssueReadModel`, the triage board, or any category filter.

**The fix:**
- The command stops writing issues. It emits an enriched `pack.audit_variance_detected` (now carrying expected/actual weight, tolerance, dim variance and auditor notes).
- New `PackAuditIssueHandler` consumes that event after commit and dispatches `CREATE_ISSUE` (`category: 'exception'`, `issueType: 'pack_audit_variance'`), then links the issue back onto `PackAudit.issueId` for the admin list's jump-to-issue. Dedup mirrors the engine rule: one open issue per pack task; repeat variances link to the existing issue.
- `scripts/fix-pack-audit-issues.ts` repairs historical orphans in place (idempotent), then `backfill-read-models.ts` materialises them. Run both after deploy.

**Behaviour change to be aware of:** `PackAudit.issueId` is now null at write time and linked within ~0.5s by the handler (pg-boss poll interval). The mobile verdict tile is unaffected; the admin list picks up the link on next fetch.

**Deliberately not done here:** `MarginAlertHandler` and `SlaEvaluationService` share the same direct-write pattern (with valid categories, so less broken); they're better converted when #133 makes the issue registry pluggable. This handler itself collapses into a registry entry at that point, and is commented as such.

**Tests:** 7 new handler tests (create, priority mapping, description content, dedup reuse, failed-dispatch, missing payload, error swallow), pack-audit command tests updated to assert no direct write + enriched payload. Full suite: 1668 tests green. `tsc` unchanged vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)