### PR TITLE
Add wms:read/wms:write permission family and guard all WMS routes (#134)

### DIFF
--- a/backend/src/__tests__/auth/wmsGuard.test.ts
+++ b/backend/src/__tests__/auth/wmsGuard.test.ts
@@ -1,0 +1,101 @@
+/**
+ * WMS route guard tests (#134).
+ *
+ * Registers the guard on a real Fastify instance with a GET and a POST
+ * route, simulates the authenticated user via an earlier preHandler
+ * (mirroring authenticateJWT populating req.user), and asserts the
+ * read/write permission split.
+ */
+
+import Fastify from 'fastify';
+import { registerWmsGuard } from '../../auth/wmsGuard';
+
+async function buildApp(permissions: string[] | null) {
+  const app = Fastify();
+  app.addHook('preHandler', async (req) => {
+    if (permissions) {
+      (req as any).user = {
+        sub: 'user-1',
+        email: 'u@test.com',
+        roles: ['test'],
+        permissions,
+      };
+    }
+  });
+  await registerWmsGuard(app);
+  app.get('/api/v1/wms/thing', async () => ({ data: 'read-ok', error: null }));
+  app.post('/api/v1/wms/thing', async () => ({ data: 'write-ok', error: null }));
+  return app;
+}
+
+describe('registerWmsGuard', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const app = await buildApp(null);
+    const res = await app.inject({ method: 'GET', url: '/api/v1/wms/thing' });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it('rejects an authenticated user with no wms permissions (403)', async () => {
+    const app = await buildApp(['shipments:read', 'orders:read']);
+    const read = await app.inject({ method: 'GET', url: '/api/v1/wms/thing' });
+    const write = await app.inject({ method: 'POST', url: '/api/v1/wms/thing' });
+    expect(read.statusCode).toBe(403);
+    expect(write.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('wms:read allows reads but not writes', async () => {
+    const app = await buildApp(['wms:read']);
+    const read = await app.inject({ method: 'GET', url: '/api/v1/wms/thing' });
+    const write = await app.inject({ method: 'POST', url: '/api/v1/wms/thing' });
+    expect(read.statusCode).toBe(200);
+    expect(write.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('wms:write allows writes', async () => {
+    const app = await buildApp(['wms:write']);
+    const write = await app.inject({ method: 'POST', url: '/api/v1/wms/thing' });
+    expect(write.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it('wms:* allows both', async () => {
+    const app = await buildApp(['wms:*']);
+    const read = await app.inject({ method: 'GET', url: '/api/v1/wms/thing' });
+    const write = await app.inject({ method: 'POST', url: '/api/v1/wms/thing' });
+    expect(read.statusCode).toBe(200);
+    expect(write.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it('the global * wildcard allows both', async () => {
+    const app = await buildApp(['*']);
+    const read = await app.inject({ method: 'GET', url: '/api/v1/wms/thing' });
+    const write = await app.inject({ method: 'POST', url: '/api/v1/wms/thing' });
+    expect(read.statusCode).toBe(200);
+    expect(write.statusCode).toBe(200);
+    await app.close();
+  });
+});
+
+describe('system role wms grants', () => {
+  // Lock the permissive defaults in so a future tightening is a conscious change
+  const { SYSTEM_ROLES } = require('../../auth/permissions');
+  const perms = (name: string) =>
+    SYSTEM_ROLES.find((r: any) => r.name === name)!.permissions;
+
+  it('warehouse role can execute warehouse tasks', () => {
+    expect(perms('warehouse')).toContain('wms:*');
+  });
+
+  it('dispatcher and readonly can view WMS surfaces', () => {
+    expect(perms('dispatcher')).toContain('wms:read');
+    expect(perms('readonly')).toContain('wms:read');
+  });
+
+  it('broker_admin has full WMS access', () => {
+    expect(perms('broker_admin')).toContain('wms:*');
+  });
+});

--- a/backend/src/auth/permissions.ts
+++ b/backend/src/auth/permissions.ts
@@ -84,6 +84,11 @@ export const PERMISSIONS = {
   AUTOMATION_RULES_READ: 'automation_rules:read',
   AUTOMATION_RULES_WRITE: 'automation_rules:write',
 
+  // WMS (warehouse operations: zones/bins, inventory, receiving, putaway,
+  // waves/picking, packing, audits, counts, replenishment, load plans, RMA)
+  WMS_READ: 'wms:read',
+  WMS_WRITE: 'wms:write',
+
   // Admin
   SETTINGS_READ: 'settings:read',
   SETTINGS_WRITE: 'settings:write',
@@ -125,6 +130,7 @@ export const SYSTEM_ROLES: RoleDefinition[] = [
       'issues:*', 'documents:*', 'tenders:*',
       'quotes:read', 'charges:read', 'invoices:read',
       'margin:view', 'credit:check', 'rate_confirmation:generate',
+      'wms:read',
     ],
     isSystem: true,
   },
@@ -141,6 +147,7 @@ export const SYSTEM_ROLES: RoleDefinition[] = [
       'edi:*', 'integrations:*',
       'agent_decisions:*', 'automation_rules:*',
       'settings:*', 'users:*', 'roles:read',
+      'wms:*',
     ],
     isSystem: true,
   },
@@ -162,12 +169,13 @@ export const SYSTEM_ROLES: RoleDefinition[] = [
   },
   {
     name: 'warehouse',
-    description: 'Warehouse operator. Can view and manage shipments at their assigned location.',
+    description: 'Warehouse operator. Can view and manage shipments at their assigned location, and execute warehouse tasks (receive, putaway, pick, pack, count, returns).',
     permissions: [
       'shipments:read', 'shipments:write',
       'orders:read',
       'devices:read', 'devices:write',
       'documents:read',
+      'wms:*',
     ],
     isSystem: true,
   },
@@ -183,6 +191,7 @@ export const SYSTEM_ROLES: RoleDefinition[] = [
       'margin:view',
       'tenders:read',
       'agent_decisions:read', 'automation_rules:read',
+      'wms:read',
     ],
     isSystem: true,
   },

--- a/backend/src/auth/wmsGuard.ts
+++ b/backend/src/auth/wmsGuard.ts
@@ -1,0 +1,24 @@
+/**
+ * WMS route guard (#134).
+ *
+ * Until this existed, every WMS surface (/api/v1/wms*, waves, picking,
+ * inventory, receiving, putaway, packing, ...) was gated only on "is
+ * authenticated" — no WMS permission family existed at all.
+ *
+ * One plugin-level hook rather than per-route preHandlers: the WMS
+ * permission model is deliberately coarse for now (read vs write by HTTP
+ * method). Finer-grained permissions (config vs task execution) can layer
+ * on top when a real need appears; see the wms.* grants in permissions.ts.
+ */
+
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { requirePermission } from '../middleware/jwtAuth.js';
+
+const READ_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export async function registerWmsGuard(server: FastifyInstance): Promise<void> {
+  server.addHook('preHandler', async (req: FastifyRequest, reply: FastifyReply) => {
+    const permission = READ_METHODS.has(req.method) ? 'wms:read' : 'wms:write';
+    await requirePermission(permission)(req, reply);
+  });
+}

--- a/backend/src/routes/cartonCatalogue.ts
+++ b/backend/src/routes/cartonCatalogue.ts
@@ -2,8 +2,12 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { container, TOKENS } from '../di/index.js';
 import { PrismaClient } from '@prisma/client';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function cartonCatalogueRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 
   // GET /api/v1/carton-catalogue?locationId=xxx&includeArchived=true

--- a/backend/src/routes/cartonization.ts
+++ b/backend/src/routes/cartonization.ts
@@ -2,8 +2,12 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { container, TOKENS } from '../di/index.js';
 import { ICartonizationService } from '../services/CartonizationService.js';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function cartonizationRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const cartonService = container.resolve<ICartonizationService>(TOKENS.ICartonizationService);
 
   // POST /api/v1/cartonization/recommend

--- a/backend/src/routes/cutoffMonitor.ts
+++ b/backend/src/routes/cutoffMonitor.ts
@@ -4,8 +4,12 @@ import { PrismaClient } from '@prisma/client';
 import { container, TOKENS } from '../di/index.js';
 import { ShipmentCutoffMonitorService } from '../services/cutoff/ShipmentCutoffMonitorService.js';
 import type { PgBossEventBus } from '../events/PgBossEventBus.js';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function cutoffMonitorRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
   const eventBus = container.resolve<PgBossEventBus>(TOKENS.IEventBus);
   const service = new ShipmentCutoffMonitorService(prisma, eventBus);

--- a/backend/src/routes/cycleCounts.ts
+++ b/backend/src/routes/cycleCounts.ts
@@ -6,8 +6,12 @@ import { CREATE_CYCLE_COUNT } from '../commands/warehouse/CreateCycleCountComman
 import { RECORD_CYCLE_COUNT_LINE } from '../commands/warehouse/RecordCycleCountLineCommand.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function cycleCountRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/inventory.ts
+++ b/backend/src/routes/inventory.ts
@@ -6,10 +6,14 @@ import { ADJUST_INVENTORY } from '../commands/warehouse/AdjustInventoryCommand.j
 import { TRANSFER_INVENTORY } from '../commands/warehouse/TransferInventoryCommand.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 const REASON_CODES = ['damage', 'expired', 'recount', 'scrap', 'found', 'return', 'other'] as const;
 
 export async function inventoryRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/loadPlans.ts
+++ b/backend/src/routes/loadPlans.ts
@@ -7,8 +7,12 @@ import { COMPLETE_LOAD_PLAN } from '../commands/warehouse/CompleteLoadPlanComman
 import { IDocumentGenerationService } from '../services/DocumentGenerationService.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function loadPlanRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/manifestIngestion.ts
+++ b/backend/src/routes/manifestIngestion.ts
@@ -6,8 +6,12 @@ import { CREATE_RECEIVING_TASK } from '../commands/warehouse/CreateReceivingTask
 import { PrismaClient, Prisma } from '@prisma/client';
 import { parseCSV, computeHeaderChecksum, applyMapping, MANIFEST_FIELDS, ColumnMapping } from '../services/ManifestIngestionService.js';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function manifestIngestionRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/packAudit.ts
+++ b/backend/src/routes/packAudit.ts
@@ -4,8 +4,12 @@ import crypto from 'crypto';
 import { container, TOKENS } from '../di/index.js';
 import { ICommandBus } from '../commands/CommandBus.js';
 import { RECORD_PACK_AUDIT } from '../commands/packAudit/RecordPackAuditCommand.js';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function packAuditRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/packing.ts
+++ b/backend/src/routes/packing.ts
@@ -8,8 +8,12 @@ import { CREATE_STAGING_ASSIGNMENT } from '../commands/warehouse/CreateStagingAs
 import { COMPLETE_LOADING } from '../commands/warehouse/CompleteLoadingCommand.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function packingRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/productUom.ts
+++ b/backend/src/routes/productUom.ts
@@ -2,8 +2,12 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { container, TOKENS } from '../di/index.js';
 import { PrismaClient } from '@prisma/client';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function productUomRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 
   // GET /api/v1/product-uom?sku=xxx

--- a/backend/src/routes/putaway.ts
+++ b/backend/src/routes/putaway.ts
@@ -6,8 +6,12 @@ import { ASSIGN_PUTAWAY_TASK } from '../commands/warehouse/AssignPutawayTaskComm
 import { COMPLETE_PUTAWAY } from '../commands/warehouse/CompletePutawayCommand.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function putawayRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/receiving.ts
+++ b/backend/src/routes/receiving.ts
@@ -8,8 +8,12 @@ import { RECORD_RECEIVING_LINE } from '../commands/warehouse/RecordReceivingLine
 import { COMPLETE_RECEIVING } from '../commands/warehouse/CompleteReceivingCommand.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function receivingRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const repo = container.resolve<IReceivingRepository>(TOKENS.IReceivingRepository);
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);

--- a/backend/src/routes/replenishment.ts
+++ b/backend/src/routes/replenishment.ts
@@ -6,8 +6,12 @@ import { CREATE_REPLENISHMENT_RULE } from '../commands/warehouse/CreateReplenish
 import { CHECK_REPLENISHMENT } from '../commands/warehouse/CheckReplenishmentCommand.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function replenishmentRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/rma.ts
+++ b/backend/src/routes/rma.ts
@@ -16,6 +16,7 @@ import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
 import { resolveActorId as resolveActorIdShared } from '../auth/orgScope.js';
 import { registerOrgScope } from '../auth/orgScopeMiddleware.js';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 const RETURN_REASONS = ['damaged', 'wrong_item', 'not_as_described', 'no_longer_needed', 'defective', 'ordered_extra', 'other'] as const;
 const DISPOSITIONS = ['restock', 'refurb', 'scrap', 'recycle', 'donate', 'rtv', 'customer_keeps'] as const;
@@ -52,6 +53,9 @@ const PARCEL_SCHEMA = {
 } as const;
 
 export async function rmaRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
   const binaryStorage = container.resolve<IBinaryStorageProvider>(TOKENS.IBinaryStorageProvider);

--- a/backend/src/routes/warehouseOperationsDashboard.ts
+++ b/backend/src/routes/warehouseOperationsDashboard.ts
@@ -2,8 +2,12 @@ import { FastifyInstance, FastifyRequest } from 'fastify';
 import { PrismaClient } from '@prisma/client';
 import { container, TOKENS } from '../di/index.js';
 import { WarehouseOperationsDashboardService } from '../services/warehouse/WarehouseOperationsDashboardService.js';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function warehouseOperationsDashboardRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
   const service = new WarehouseOperationsDashboardService(prisma);
 

--- a/backend/src/routes/warehouseZones.ts
+++ b/backend/src/routes/warehouseZones.ts
@@ -9,12 +9,16 @@ import { CREATE_WAREHOUSE_BIN } from '../commands/warehouse/CreateWarehouseBinCo
 import { UPDATE_WAREHOUSE_BIN } from '../commands/warehouse/UpdateWarehouseBinCommand.js';
 import { BULK_CREATE_BINS } from '../commands/warehouse/BulkCreateBinsCommand.js';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 const ZONE_TYPES = ['receiving', 'bulk_storage', 'pick_face', 'staging', 'packing', 'shipping_dock', 'quarantine', 'returns', 'cross_dock'] as const;
 const BIN_TYPES = ['pallet', 'shelf', 'floor', 'dock_door', 'staging', 'pack_station'] as const;
 const TEMP_ZONES = ['ambient', 'refrigerated', 'frozen'] as const;
 
 export async function warehouseZoneRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const repo = container.resolve<IWarehouseZoneRepository>(TOKENS.IWarehouseZoneRepository);
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
 

--- a/backend/src/routes/waveTemplates.ts
+++ b/backend/src/routes/waveTemplates.ts
@@ -6,8 +6,12 @@ import { CREATE_WAVE_TEMPLATE } from '../commands/warehouse/CreateWaveTemplateCo
 import { APPLY_WAVE_TEMPLATE } from '../commands/warehouse/ApplyWaveTemplateCommand.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function waveTemplateRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/waves.ts
+++ b/backend/src/routes/waves.ts
@@ -7,8 +7,12 @@ import { RELEASE_WAVE } from '../commands/warehouse/ReleaseWaveCommand.js';
 import { COMPLETE_PICK_LINE } from '../commands/warehouse/CompletePickLineCommand.js';
 import { PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function waveRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const commandBus = container.resolve<ICommandBus>(TOKENS.ICommandBus);
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 

--- a/backend/src/routes/wmsDashboard.ts
+++ b/backend/src/routes/wmsDashboard.ts
@@ -1,8 +1,12 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { container, TOKENS } from '../di/index.js';
 import { PrismaClient } from '@prisma/client';
+import { registerWmsGuard } from '../auth/wmsGuard.js';
 
 export async function wmsDashboardRoutes(server: FastifyInstance) {
+  // WMS permission guard (#134): wms:read for reads, wms:write for mutations
+  await registerWmsGuard(server);
+
   const prisma = container.resolve<PrismaClient>(TOKENS.PrismaClient);
 
   // GET /api/v1/wms/dashboard?locationId=xxx


### PR DESCRIPTION
Closes #134.

Every WMS surface was gated only on "is authenticated". This adds a `wms:read` / `wms:write` permission pair and a plugin-level guard (reads need read, mutations need write) on all 19 WMS route plugins: zones, inventory, receiving, putaway, waves, wave templates, packing, pack audits, cycle counts, replenishment, load plans, manifest ingestion, product UOM, carton catalogue, cartonization, RMA, cutoff monitor, and both WMS dashboards.

Role defaults are permissive so nothing breaks on deploy: `warehouse` and `broker_admin` get `wms:*`, `dispatcher` and `readonly` get `wms:read`, `admin` already has `*`. `seedRoles` updates system roles on boot, so the grants land automatically. Tightening (e.g. a separate config permission for zones/templates/rules) is deliberately left until there's a real need.

Not guarded on purpose: `warehouse.ts` (the PWA shipment-launch surface, TMS-side, org-scoped in #136) and `packagingTypes.ts` (TMS model that only lives under /wms in the nav).

Tests: 9 new (guard split, wildcards, 401/403, role grants locked in). Full suite 1670 green, tsc unchanged vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)