### PR TITLE
Scope warehouse session tokens to warehouse/WMS routes (#135)

### DIFF
--- a/.claude/rules/multi-tenancy.md
+++ b/.claude/rules/multi-tenancy.md
@@ -33,7 +33,7 @@ paths:
 | Admin app | `authenticateJWT` | `registerOrgScope(server)` |
 | Customer portal | `authenticateCustomerJWT` + `req.customerUser` | `attachOrgScopeFromCustomerUserHook(server.prisma)` — walks `customerUser.customerId → Customer.orgId` |
 | Carrier portal | `authenticateCarrierJWT` + `req.carrierUser` | `attachOrgScopeFromCarrierUserHook(server.prisma)` — walks `carrierUser.carrierId → Carrier.orgId` |
-| Warehouse PWA | `authenticateJWT` (same JWT shape as admin login) | `registerOrgScope(server)` |
+| Warehouse PWA | `authenticateJWT` (same JWT shape as admin login, plus `scope: 'warehouse'` which restricts the token to warehouse/WMS task routes) | `registerOrgScope(server)` |
 | EDI inbound | mixed authed admin + unauthed webhook | `await registerOrgScopeForEdi(server)` |
 
 **Warehouse PWA:** the magic-link validate and password login endpoints both return a session JWT

--- a/backend/src/__tests__/jwtAuth.test.ts
+++ b/backend/src/__tests__/jwtAuth.test.ts
@@ -10,10 +10,12 @@ function makeToken(payload: Record<string, any>, secret = JWT_SECRET): string {
   return `${header}.${body}.${signature}`;
 }
 
-function mockReq(authHeader?: string): any {
+function mockReq(authHeader?: string, method = 'GET', url = '/api/v1/shipments'): any {
   return {
     headers: authHeader ? { authorization: authHeader } : {},
     user: undefined,
+    method,
+    url,
   };
 }
 
@@ -91,6 +93,65 @@ describe('jwtAuth', () => {
       await authenticateJWT(req, reply);
 
       expect(reply.code).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe('authenticateJWT warehouse scope', () => {
+    const scopedPayload = {
+      sub: 'op-1',
+      email: 'op@example.com',
+      roles: ['warehouse'],
+      permissions: ['wms:*', 'shipments:read', 'shipments:write'],
+      scope: 'warehouse',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      iss: 'open-tms-auth',
+    };
+
+    it.each([
+      ['GET', '/api/v1/warehouse/shipments'],
+      ['POST', '/api/v1/warehouse/shipments/abc/launch'],
+      ['PUT', '/api/v1/pick-lines/pl-1/complete'],
+      ['POST', '/api/v1/pack-audits'],
+      ['GET', '/api/v1/receiving/tasks'],
+      ['GET', '/api/v1/rmas/rma-1'],
+      ['GET', '/api/v1/carriers'],
+      ['GET', '/api/v1/customers'],
+    ])('allows a scoped session on %s %s', async (method, url) => {
+      const req = mockReq(`Bearer ${makeToken(scopedPayload)}`, method, url);
+      const reply = mockReply();
+
+      await authenticateJWT(req, reply);
+
+      expect(req.user).toBeDefined();
+      expect(reply.code).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['GET', '/api/v1/shipments'],
+      ['GET', '/api/v1/invoices'],
+      ['POST', '/api/v1/carriers'],
+      ['POST', '/api/v1/customers'],
+      ['GET', '/api/v1/users'],
+      ['PUT', '/api/v1/settings/llm'],
+    ])('refuses a scoped session on %s %s with 403', async (method, url) => {
+      const req = mockReq(`Bearer ${makeToken(scopedPayload)}`, method, url);
+      const reply = mockReply();
+
+      await authenticateJWT(req, reply);
+
+      expect(req.user).toBeUndefined();
+      expect(reply.code).toHaveBeenCalledWith(403);
+    });
+
+    it('leaves unscoped tokens unrestricted (transition: pre-#135 sessions keep working)', async () => {
+      const { scope, ...unscoped } = scopedPayload;
+      const req = mockReq(`Bearer ${makeToken(unscoped)}`, 'GET', '/api/v1/shipments');
+      const reply = mockReply();
+
+      await authenticateJWT(req, reply);
+
+      expect(req.user).toBeDefined();
+      expect(reply.code).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/__tests__/services/WarehouseService.test.ts
+++ b/backend/src/__tests__/services/WarehouseService.test.ts
@@ -216,6 +216,9 @@ describe('WarehouseService', () => {
         expect(payload.iss).toBe('open-tms-auth');
         expect(payload.sub).toBe('user-1');
         expect(payload.organizationId).toBe(mockUser.organizationId);
+        // Warehouse logins mint a scoped session: authenticateJWT only
+        // accepts it on warehouse/WMS task routes (#135)
+        expect(payload.scope).toBe('warehouse');
       }
     });
 
@@ -368,6 +371,9 @@ describe('WarehouseService', () => {
         expect(payload.iss).toBe('open-tms-auth');
         expect(payload.sub).toBe('user-1');
         expect(payload.organizationId).toBe(mockUser.organizationId);
+        // Warehouse logins mint a scoped session: authenticateJWT only
+        // accepts it on warehouse/WMS task routes (#135)
+        expect(payload.scope).toBe('warehouse');
         expect(payload.roles).toEqual(['warehouse']);
       }
     });

--- a/backend/src/auth/internalJWT.ts
+++ b/backend/src/auth/internalJWT.ts
@@ -26,6 +26,13 @@ export interface InternalJWTClaims {
   roles: string[];
   permissions: string[];
   organizationId?: string;
+  /**
+   * Surface restriction. 'warehouse' marks a session minted by the
+   * warehouse PWA login (magic link or password): authenticateJWT only
+   * accepts it on warehouse/WMS task routes, so a leaked operative token
+   * cannot reach the wider admin API. Absent = unrestricted admin session.
+   */
+  scope?: 'warehouse';
 }
 
 /**

--- a/backend/src/middleware/jwtAuth.ts
+++ b/backend/src/middleware/jwtAuth.ts
@@ -12,6 +12,8 @@ export interface JWTPayload {
   permissions: string[];
   organizationId?: string;
   customerId?: string;
+  /** 'warehouse' = PWA session, accepted only on warehouse/WMS task routes. */
+  scope?: 'warehouse';
   iat?: number;
   exp?: number;
   iss?: string;
@@ -89,8 +91,42 @@ function verifyJWT(token: string): JWTPayload {
 }
 
 /**
+ * Routes a warehouse-scoped session may reach: the PWA surface itself plus
+ * the WMS task routes its screens call (pick/pack/putaway/receiving/returns,
+ * pack audits, carton catalogue). Read-only carriers/customers lookups are
+ * allowed for the create-shipment screen. Everything else on the admin API
+ * is off-limits to a scoped token — a magic link can hang on a printed QR
+ * code, so a leaked one must not open the whole system.
+ */
+const WAREHOUSE_SCOPE_PREFIXES = [
+  '/api/v1/warehouse/',
+  '/api/v1/pick-tasks',
+  '/api/v1/pick-lines/',
+  '/api/v1/pack-tasks',
+  '/api/v1/pack-lines/',
+  '/api/v1/pack-audits',
+  '/api/v1/putaway/',
+  '/api/v1/receiving/',
+  '/api/v1/rmas',
+  '/api/v1/rma-lines/',
+  '/api/v1/carton-catalogue',
+];
+const WAREHOUSE_SCOPE_READONLY_PREFIXES = [
+  '/api/v1/carriers',
+  '/api/v1/customers',
+];
+
+function warehouseScopeAllows(method: string, url: string): boolean {
+  const path = url.split('?')[0];
+  if (WAREHOUSE_SCOPE_PREFIXES.some(p => path.startsWith(p))) return true;
+  if (method === 'GET' && WAREHOUSE_SCOPE_READONLY_PREFIXES.some(p => path.startsWith(p))) return true;
+  return false;
+}
+
+/**
  * Fastify preHandler hook: extracts and validates JWT from Authorization header.
- * Sets req.user if valid. Sends 401 if missing or invalid.
+ * Sets req.user if valid. Sends 401 if missing or invalid, 403 when a
+ * warehouse-scoped session tries to reach a non-warehouse route.
  */
 export async function authenticateJWT(req: FastifyRequest, reply: FastifyReply): Promise<void> {
   const authHeader = req.headers.authorization;
@@ -101,11 +137,20 @@ export async function authenticateJWT(req: FastifyRequest, reply: FastifyReply):
 
   const token = authHeader.slice(7);
 
+  let payload: JWTPayload;
   try {
-    req.user = verifyJWT(token);
+    payload = verifyJWT(token);
   } catch {
     reply.code(401).send({ data: null, error: 'Invalid or expired token' });
+    return;
   }
+
+  if (payload.scope === 'warehouse' && !warehouseScopeAllows(req.method, req.url)) {
+    reply.code(403).send({ data: null, error: 'Warehouse session cannot access this resource' });
+    return;
+  }
+
+  req.user = payload;
 }
 
 /**

--- a/backend/src/services/WarehouseService.ts
+++ b/backend/src/services/WarehouseService.ts
@@ -226,6 +226,10 @@ export class WarehouseService {
    * subsequent warehouse request.
    */
   private signSessionToken(user: WarehouseUser): string {
+    // BUSINESS RULE: warehouse logins (magic link or password) mint a
+    // scoped session, not a general admin token. Magic links can hang on
+    // a printed QR code in a warehouse; if one leaks it must only open
+    // the warehouse/WMS task surface, never the whole admin API.
     return signInternalJWT({
       sub: user.id,
       email: user.email,
@@ -234,6 +238,7 @@ export class WarehouseService {
       roles: user.roles,
       permissions: user.permissions,
       organizationId: user.organizationId ?? undefined,
+      scope: 'warehouse',
     });
   }
 


### PR DESCRIPTION
Closes #135.

Warehouse magic links can hang on a printed QR code, and until now validating one handed back a full internal JWT indistinguishable from an admin login. Now both warehouse login paths mint the same token with `scope: 'warehouse'`, and `authenticateJWT` refuses scoped tokens with 403 anywhere outside the warehouse/WMS task surface. The allowlist was built from what the PWA actually calls (grepped, not guessed): the /warehouse routes, pick/pack/putaway/receiving/returns tasks, pack audits, carton catalogue, and read-only carriers/customers for the create-shipment screen.

Old tokens have no scope claim and stay unrestricted until they expire (12h), so nothing needs coordinating on deploy.

Note: the PWA still doesn't send its token at all (#137), so operatives are 401ing regardless. When #137 wires the client up it inherits this scoping for free.

Tests: allow/refuse matrix across 14 routes, the unscoped transition case, and the scope claim on the login payload. Full suite 1676 green, tsc unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)