### PR TITLE
Role & permission management UI, guard role routes (#142)

### DIFF
--- a/backend/src/__tests__/routes/roles.guard.test.ts
+++ b/backend/src/__tests__/routes/roles.guard.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Role route guard tests (#142).
+ *
+ * Before this, no mutating role route had a permission guard: any
+ * authenticated user could create a role with '*' and assign it to
+ * themselves. These tests register the real plugin and assert
+ * roles:read / roles:write enforcement plus the system-role edit refusal
+ * (system roles are re-synced from code on boot, so edits would silently
+ * revert).
+ */
+
+import Fastify from 'fastify';
+import { roleRoutes } from '../../routes/roles';
+
+const SYSTEM_ROLE = { id: 'r-sys', name: 'admin', isSystem: true, permissions: ['*'] };
+const CUSTOM_ROLE = { id: 'r-custom', name: 'wms-supervisor', isSystem: false, permissions: ['wms:*'] };
+
+function buildPrisma() {
+  return {
+    role: {
+      findMany: jest.fn().mockResolvedValue([SYSTEM_ROLE, CUSTOM_ROLE]),
+      findUnique: jest.fn().mockImplementation(({ where }: any) => {
+        if (where.id === 'r-sys' || where.name === 'admin') return Promise.resolve(SYSTEM_ROLE);
+        if (where.id === 'r-custom' || where.name === 'wms-supervisor') return Promise.resolve(CUSTOM_ROLE);
+        return Promise.resolve(null);
+      }),
+      create: jest.fn().mockImplementation(({ data }: any) => Promise.resolve({ id: 'r-new', ...data })),
+      update: jest.fn().mockImplementation(({ where, data }: any) => Promise.resolve({ ...CUSTOM_ROLE, ...data, id: where.id })),
+      delete: jest.fn().mockResolvedValue({}),
+    },
+    user: { findUnique: jest.fn().mockResolvedValue({ id: 'u-1' }) },
+    userRole: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue({ id: 'ur-1' }),
+      delete: jest.fn().mockResolvedValue({}),
+    },
+  } as any;
+}
+
+async function buildApp(permissions: string[]) {
+  const app = Fastify();
+  app.decorate('prisma', buildPrisma());
+  app.addHook('preHandler', async (req) => {
+    (req as any).user = { sub: 'u-1', email: 'u@test.com', roles: ['x'], permissions };
+  });
+  await app.register(roleRoutes);
+  return app;
+}
+
+describe('role route guards', () => {
+  it('reads require roles:read', async () => {
+    const app = await buildApp(['shipments:read']);
+    for (const url of ['/api/v1/roles', '/api/v1/roles/permissions', '/api/v1/roles/r-custom']) {
+      const res = await app.inject({ method: 'GET', url });
+      expect(res.statusCode).toBe(403);
+    }
+    await app.close();
+  });
+
+  it('roles:read can list roles and the permission catalogue', async () => {
+    const app = await buildApp(['roles:read']);
+    const list = await app.inject({ method: 'GET', url: '/api/v1/roles' });
+    const cat = await app.inject({ method: 'GET', url: '/api/v1/roles/permissions' });
+    expect(list.statusCode).toBe(200);
+    expect(cat.statusCode).toBe(200);
+    // The catalogue is served straight from PERMISSIONS, so anything added
+    // there (e.g. the wms family from #134) appears with no further work
+    expect(JSON.parse(cat.body).data).toHaveProperty('ROLES_READ', 'roles:read');
+    await app.close();
+  });
+
+  it('roles:read alone cannot create, edit, delete, or assign', async () => {
+    const app = await buildApp(['roles:read']);
+    const cases = [
+      { method: 'POST' as const, url: '/api/v1/roles', payload: { name: 'x', permissions: ['wms:read'] } },
+      { method: 'PUT' as const, url: '/api/v1/roles/r-custom', payload: { permissions: ['wms:read'] } },
+      { method: 'DELETE' as const, url: '/api/v1/roles/r-custom' },
+      { method: 'POST' as const, url: '/api/v1/roles/r-custom/users/u-1' },
+      { method: 'DELETE' as const, url: '/api/v1/roles/r-custom/users/u-1' },
+      { method: 'POST' as const, url: '/api/v1/roles/seed' },
+    ];
+    for (const c of cases) {
+      const res = await app.inject(c);
+      expect(res.statusCode).toBe(403);
+    }
+    await app.close();
+  });
+
+  it('roles:write can create a custom role', async () => {
+    const app = await buildApp(['roles:write']);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/roles',
+      payload: { name: 'new-role', description: 'test', permissions: ['wms:read', 'wms:write'] },
+    });
+    expect(res.statusCode).toBe(201);
+    await app.close();
+  });
+
+  it('refuses editing a system role with a clear error', async () => {
+    const app = await buildApp(['roles:write']);
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/roles/r-sys',
+      payload: { permissions: ['shipments:read'] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain('managed in code');
+    expect((app as any).prisma.role.update).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('allows editing a custom role', async () => {
+    const app = await buildApp(['roles:write']);
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/roles/r-custom',
+      payload: { permissions: ['wms:read'] },
+    });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+});

--- a/backend/src/routes/roles.ts
+++ b/backend/src/routes/roles.ts
@@ -1,13 +1,10 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { PERMISSIONS, SYSTEM_ROLES } from '../auth/permissions.js';
+import { requirePermission } from '../middleware/jwtAuth.js';
 import { seedSystemRoles } from '../auth/seedRoles.js';
 
 export async function roleRoutes(server: FastifyInstance) {
-  const getOrgId = async () => {
-    const org = await server.prisma.organization.findFirst({ select: { id: true } });
-    return org?.id || 'default';
-  };
 
   // List all roles
   server.get('/api/v1/roles', {
@@ -15,6 +12,7 @@ export async function roleRoutes(server: FastifyInstance) {
       tags: ['Roles & Permissions'],
       summary: 'List all roles with their permissions',
     },
+    preHandler: requirePermission('roles:read'),
   }, async () => {
     const roles = await server.prisma.role.findMany({
       include: {
@@ -31,6 +29,7 @@ export async function roleRoutes(server: FastifyInstance) {
       tags: ['Roles & Permissions'],
       summary: 'Get the full catalog of available permissions',
     },
+    preHandler: requirePermission('roles:read'),
   }, async () => {
     return { data: PERMISSIONS, error: null };
   });
@@ -41,6 +40,7 @@ export async function roleRoutes(server: FastifyInstance) {
       tags: ['Roles & Permissions'],
       params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
     },
+    preHandler: requirePermission('roles:read'),
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { id } = req.params as { id: string };
     const role = await server.prisma.role.findUnique({
@@ -70,6 +70,7 @@ export async function roleRoutes(server: FastifyInstance) {
         },
       },
     },
+    preHandler: requirePermission('roles:write'),
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const body = z.object({
       name: z.string().min(1).max(50),
@@ -108,6 +109,7 @@ export async function roleRoutes(server: FastifyInstance) {
         },
       },
     },
+    preHandler: requirePermission('roles:write'),
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { id } = req.params as { id: string };
     const body = z.object({
@@ -117,6 +119,12 @@ export async function roleRoutes(server: FastifyInstance) {
 
     const role = await server.prisma.role.findUnique({ where: { id } });
     if (!role) { reply.code(404); return { data: null, error: 'Role not found' }; }
+    if (role.isSystem) {
+      // seedSystemRoles() re-syncs system roles from code on every boot,
+      // so an edit here would silently revert. Refuse loudly instead.
+      reply.code(400);
+      return { data: null, error: 'System roles are managed in code and cannot be edited. Create a custom role instead.' };
+    }
 
     const updated = await server.prisma.role.update({ where: { id }, data: body });
     return { data: updated, error: null };
@@ -125,6 +133,7 @@ export async function roleRoutes(server: FastifyInstance) {
   // Delete a custom role (system roles cannot be deleted)
   server.delete('/api/v1/roles/:id', {
     schema: { tags: ['Roles & Permissions'] },
+    preHandler: requirePermission('roles:write'),
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { id } = req.params as { id: string };
     const role = await server.prisma.role.findUnique({ where: { id } });
@@ -141,6 +150,7 @@ export async function roleRoutes(server: FastifyInstance) {
       tags: ['Roles & Permissions'],
       summary: 'Assign a role to a user',
     },
+    preHandler: requirePermission('roles:write'),
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { roleId, userId } = req.params as { roleId: string; userId: string };
 
@@ -168,6 +178,7 @@ export async function roleRoutes(server: FastifyInstance) {
   // Remove a role from a user
   server.delete('/api/v1/roles/:roleId/users/:userId', {
     schema: { tags: ['Roles & Permissions'] },
+    preHandler: requirePermission('roles:write'),
   }, async (req: FastifyRequest, reply: FastifyReply) => {
     const { roleId, userId } = req.params as { roleId: string; userId: string };
 
@@ -186,6 +197,7 @@ export async function roleRoutes(server: FastifyInstance) {
       tags: ['Roles & Permissions'],
       summary: 'Seed or update system roles (idempotent)',
     },
+    preHandler: requirePermission('roles:write'),
   }, async () => {
     const result = await seedSystemRoles(server.prisma);
     return { data: result, error: null };

--- a/frontend/src/vnext-design/VNextRoles.tsx
+++ b/frontend/src/vnext-design/VNextRoles.tsx
@@ -1,10 +1,22 @@
-import React, { useEffect, useState } from 'react';
-import { ShieldCheck, RefreshCw, Loader2 } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ShieldCheck, RefreshCw, Loader2, Plus, Pencil, Trash2, Lock } from 'lucide-react';
 
 import { API_URL } from '../api';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
 
 interface Role {
   id: string;
@@ -16,7 +28,9 @@ interface Role {
   createdAt: string;
 }
 
-function permissionVariant(name: string): 'info' | 'success' | 'warning' | 'secondary' | 'default' {
+const FULL_ACCESS = '*';
+
+function roleBadgeVariant(name: string): 'info' | 'success' | 'warning' | 'secondary' | 'default' {
   if (name === 'admin' || name === 'broker_admin') return 'default';
   if (name.includes('broker')) return 'info';
   if (name === 'finance') return 'success';
@@ -33,19 +47,150 @@ function Banner({ variant, message }: { variant: 'success' | 'error'; message: s
   return <div className={`rounded-md border p-3 text-sm ${tone}`}>{message}</div>;
 }
 
+/** Group the flat catalogue ('shipments:read', ...) by resource prefix. */
+function groupCatalogue(perms: string[]): Map<string, string[]> {
+  const groups = new Map<string, string[]>();
+  for (const perm of perms) {
+    if (perm === FULL_ACCESS) continue;
+    const resource = perm.split(':')[0];
+    groups.set(resource, [...(groups.get(resource) ?? []), perm]);
+  }
+  return groups;
+}
+
+function PermissionToggle({
+  label,
+  selected,
+  implied,
+  onToggle,
+}: {
+  label: string;
+  selected: boolean;
+  implied: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={selected || implied}
+      disabled={implied}
+      onClick={onToggle}
+      className={cn(
+        'rounded-md border px-2 py-1 text-xs transition-colors',
+        selected
+          ? 'border-primary bg-primary text-primary-foreground'
+          : implied
+            ? 'border-border bg-muted text-muted-foreground'
+            : 'border-border bg-background text-foreground hover:bg-accent hover:text-accent-foreground',
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function PermissionPicker({
+  catalogue,
+  selected,
+  onChange,
+}: {
+  catalogue: string[];
+  selected: Set<string>;
+  onChange: (next: Set<string>) => void;
+}) {
+  const groups = useMemo(() => groupCatalogue(catalogue), [catalogue]);
+  const hasFullAccess = selected.has(FULL_ACCESS);
+
+  const toggle = (perm: string) => {
+    const next = new Set(selected);
+    if (next.has(perm)) next.delete(perm);
+    else next.add(perm);
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <PermissionToggle
+          label="Full access (*)"
+          selected={hasFullAccess}
+          implied={false}
+          onToggle={() => toggle(FULL_ACCESS)}
+        />
+        <span className="text-xs text-muted-foreground">Grants everything, including future permissions.</span>
+      </div>
+      <Separator />
+      <div className="max-h-72 space-y-3 overflow-y-auto pr-1">
+        {Array.from(groups.entries()).map(([resource, perms]) => {
+          const wildcard = `${resource}:*`;
+          const hasWildcard = selected.has(wildcard);
+          return (
+            <div key={resource}>
+              <div className="mb-1.5 flex items-center gap-2">
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {resource.replace(/_/g, ' ')}
+                </span>
+                <PermissionToggle
+                  label={`all (${wildcard})`}
+                  selected={hasWildcard}
+                  implied={hasFullAccess}
+                  onToggle={() => toggle(wildcard)}
+                />
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {perms.map(perm => (
+                  <PermissionToggle
+                    key={perm}
+                    label={perm}
+                    selected={selected.has(perm)}
+                    implied={hasFullAccess || hasWildcard}
+                    onToggle={() => toggle(perm)}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface EditorState {
+  mode: 'create' | 'edit';
+  roleId?: string;
+  name: string;
+  description: string;
+  permissions: Set<string>;
+}
+
 export default function VNextRoles() {
   const [roles, setRoles] = useState<Role[]>([]);
+  const [catalogue, setCatalogue] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [seeding, setSeeding] = useState(false);
-  const [seedMessage, setSeedMessage] = useState('');
+  const [banner, setBanner] = useState<{ variant: 'success' | 'error'; message: string } | null>(null);
+
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [editorError, setEditorError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<Role | null>(null);
 
   const loadRoles = async () => {
     try {
       setLoading(true);
-      const res = await fetch(`${API_URL}/api/v1/roles`);
-      const json = await res.json();
-      setRoles(json.data || []);
+      setError('');
+      const [rolesRes, catRes] = await Promise.all([
+        fetch(`${API_URL}/api/v1/roles`),
+        fetch(`${API_URL}/api/v1/roles/permissions`),
+      ]);
+      const rolesJson = await rolesRes.json();
+      const catJson = await catRes.json();
+      if (!rolesRes.ok) throw new Error(rolesJson.error || 'Failed to load roles');
+      setRoles(rolesJson.data || []);
+      setCatalogue(Object.values(catJson.data || {}) as string[]);
     } catch (err: any) {
       setError(err.message);
     } finally {
@@ -57,18 +202,91 @@ export default function VNextRoles() {
 
   const handleSeedRoles = async () => {
     setSeeding(true);
-    setSeedMessage('');
+    setBanner(null);
     try {
       const res = await fetch(`${API_URL}/api/v1/roles/seed`, { method: 'POST' });
       const json = await res.json();
-      if (json.data) {
-        setSeedMessage(`Created ${json.data.created} roles, updated ${json.data.updated} existing roles`);
-        loadRoles();
-      }
-    } catch {
-      setSeedMessage('Failed to seed roles');
+      if (!res.ok) throw new Error(json.error || 'Failed to seed roles');
+      setBanner({ variant: 'success', message: `Created ${json.data.created} roles, updated ${json.data.updated} existing roles` });
+      loadRoles();
+    } catch (err: any) {
+      setBanner({ variant: 'error', message: err.message });
     } finally {
       setSeeding(false);
+    }
+  };
+
+  const openCreate = () => {
+    setEditorError('');
+    setEditor({ mode: 'create', name: '', description: '', permissions: new Set() });
+  };
+
+  const openEdit = (role: Role) => {
+    setEditorError('');
+    setEditor({
+      mode: 'edit',
+      roleId: role.id,
+      name: role.name,
+      description: role.description || '',
+      permissions: new Set(role.permissions),
+    });
+  };
+
+  const handleSave = async () => {
+    if (!editor) return;
+    if (editor.mode === 'create' && !editor.name.trim()) {
+      setEditorError('Role name is required');
+      return;
+    }
+    if (editor.permissions.size === 0) {
+      setEditorError('Select at least one permission');
+      return;
+    }
+    setSaving(true);
+    setEditorError('');
+    try {
+      const payload = {
+        ...(editor.mode === 'create' ? { name: editor.name.trim() } : {}),
+        description: editor.description.trim() || undefined,
+        permissions: Array.from(editor.permissions),
+      };
+      const res = await fetch(
+        editor.mode === 'create'
+          ? `${API_URL}/api/v1/roles`
+          : `${API_URL}/api/v1/roles/${editor.roleId}`,
+        {
+          method: editor.mode === 'create' ? 'POST' : 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        },
+      );
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Failed to save role');
+      setBanner({ variant: 'success', message: editor.mode === 'create' ? `Role "${editor.name}" created` : 'Role updated' });
+      setEditor(null);
+      loadRoles();
+    } catch (err: any) {
+      setEditorError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleting) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`${API_URL}/api/v1/roles/${deleting.id}`, { method: 'DELETE' });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Failed to delete role');
+      setBanner({ variant: 'success', message: `Role "${deleting.name}" deleted` });
+      setDeleting(null);
+      loadRoles();
+    } catch (err: any) {
+      setBanner({ variant: 'error', message: err.message });
+      setDeleting(null);
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -79,14 +297,20 @@ export default function VNextRoles() {
           <h1 className="text-3xl font-bold tracking-tight">Roles and permissions</h1>
           <p className="mt-1 text-sm text-muted-foreground">Manage user roles and their associated permissions</p>
         </div>
-        <Button variant="outline" onClick={handleSeedRoles} disabled={seeding}>
-          {seeding ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-          {seeding ? 'Seeding...' : 'Seed system roles'}
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={handleSeedRoles} disabled={seeding}>
+            {seeding ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            {seeding ? 'Seeding...' : 'Seed system roles'}
+          </Button>
+          <Button variant="gradient" onClick={openCreate}>
+            <Plus className="h-4 w-4" />
+            New role
+          </Button>
+        </div>
       </div>
 
       {error && <Banner variant="error" message={error} />}
-      {seedMessage && <Banner variant="success" message={seedMessage} />}
+      {banner && <Banner variant={banner.variant} message={banner.message} />}
 
       {loading ? (
         <div className="flex justify-center py-12">
@@ -97,10 +321,11 @@ export default function VNextRoles() {
           <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
             <ShieldCheck className="h-10 w-10 text-muted-foreground" />
             <h3 className="text-lg font-medium">No roles defined</h3>
-            <p className="text-sm text-muted-foreground">Click "Seed system roles" to create the default roles.</p>
-            <Button variant="gradient" onClick={handleSeedRoles} disabled={seeding}>
-              Seed system roles
-            </Button>
+            <p className="text-sm text-muted-foreground">Seed the system roles, or create a custom role from scratch.</p>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={handleSeedRoles} disabled={seeding}>Seed system roles</Button>
+              <Button variant="gradient" onClick={openCreate}>New role</Button>
+            </div>
           </CardContent>
         </Card>
       ) : (
@@ -112,7 +337,7 @@ export default function VNextRoles() {
                   <div>
                     <div className="flex items-center gap-2">
                       <span className="text-base font-semibold">{role.name}</span>
-                      <Badge variant={permissionVariant(role.name)}>{role.isSystem ? 'System' : 'Custom'}</Badge>
+                      <Badge variant={roleBadgeVariant(role.name)}>{role.isSystem ? 'System' : 'Custom'}</Badge>
                     </div>
                     <p className="mt-1 text-sm text-muted-foreground">{role.description || 'No description'}</p>
                   </div>
@@ -120,21 +345,114 @@ export default function VNextRoles() {
                     {role._count?.users ?? 0} user{(role._count?.users ?? 0) !== 1 ? 's' : ''}
                   </div>
                 </div>
-                <div className="flex flex-wrap gap-1">
-                  {(role.permissions as string[]).slice(0, 8).map((p, i) => (
+                <div className="mb-3 flex flex-wrap gap-1">
+                  {role.permissions.slice(0, 8).map((p, i) => (
                     <Badge key={i} variant="secondary" className="text-[10px]">{p}</Badge>
                   ))}
-                  {(role.permissions as string[]).length > 8 && (
+                  {role.permissions.length > 8 && (
                     <Badge variant="secondary" className="text-[10px]">
-                      +{(role.permissions as string[]).length - 8} more
+                      +{role.permissions.length - 8} more
                     </Badge>
                   )}
                 </div>
+                {role.isSystem ? (
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Lock className="h-3 w-3" aria-hidden />
+                    Managed in code and re-synced on startup
+                  </div>
+                ) : (
+                  <div className="flex gap-2">
+                    <Button variant="outline" size="sm" onClick={() => openEdit(role)}>
+                      <Pencil className="h-3.5 w-3.5" />
+                      Edit
+                    </Button>
+                    <Button variant="outline" size="sm" onClick={() => setDeleting(role)}>
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Delete
+                    </Button>
+                  </div>
+                )}
               </CardContent>
             </Card>
           ))}
         </div>
       )}
+
+      {/* Create / edit dialog */}
+      <Dialog open={editor !== null} onOpenChange={(open) => { if (!open) setEditor(null); }}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{editor?.mode === 'create' ? 'New role' : `Edit ${editor?.name}`}</DialogTitle>
+            <DialogDescription>
+              {editor?.mode === 'create'
+                ? 'Name the role and pick its permissions. Wildcards cover every action on a resource.'
+                : 'Change the description or permissions. The name is fixed once created.'}
+            </DialogDescription>
+          </DialogHeader>
+          {editor && (
+            <div className="space-y-4">
+              {editor.mode === 'create' && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="role-name">Name</Label>
+                  <Input
+                    id="role-name"
+                    value={editor.name}
+                    onChange={(e) => setEditor({ ...editor, name: e.target.value })}
+                    placeholder="e.g. wms-supervisor"
+                    maxLength={50}
+                  />
+                </div>
+              )}
+              <div className="space-y-1.5">
+                <Label htmlFor="role-description">Description</Label>
+                <Input
+                  id="role-description"
+                  value={editor.description}
+                  onChange={(e) => setEditor({ ...editor, description: e.target.value })}
+                  placeholder="What this role is for"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Permissions</Label>
+                <PermissionPicker
+                  catalogue={catalogue}
+                  selected={editor.permissions}
+                  onChange={(permissions) => setEditor({ ...editor, permissions })}
+                />
+              </div>
+              {editorError && <Banner variant="error" message={editorError} />}
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditor(null)} disabled={saving}>Cancel</Button>
+            <Button variant="gradient" onClick={handleSave} disabled={saving}>
+              {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+              {editor?.mode === 'create' ? 'Create role' : 'Save changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirm */}
+      <Dialog open={deleting !== null} onOpenChange={(open) => { if (!open) setDeleting(null); }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete {deleting?.name}?</DialogTitle>
+            <DialogDescription>
+              {deleting?._count?.users
+                ? `${deleting._count.users} user${deleting._count.users !== 1 ? 's' : ''} currently hold this role and will lose its permissions.`
+                : 'No users currently hold this role.'}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleting(null)} disabled={saving}>Cancel</Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={saving}>
+              {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+              Delete role
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/roadmap.md
+++ b/roadmap.md
@@ -652,6 +652,8 @@ Items from the unified trading partner model that are not yet complete:
 - Pluggable map provider interface 🔲
 
 ### **Internal User Auth Improvements**
+
+- **Role & permission management UI** ✅ (#142) - create/edit/delete custom roles from /settings with a grouped permission picker (catalogue-driven, so new permission families appear automatically); system roles locked in the UI and on the API (seeder re-syncs them on boot); roles:read/roles:write guards added to all role routes, closing a privilege-escalation hole where any authenticated user could create and self-assign a '*' role
 Base login (email + password, JWT, admin password reset, RequireAuth guard, global 401 → /login interceptor) is shipped. Improvements to harden and productionise:
 
 - **Self-service password reset via email** 🔲 - `/api/v1/auth/forgot-password` is currently a stub that only logs. Implement: time-limited signed reset token, reset-password page (`/reset-password?token=...`), email delivery via the existing EmailService + EmailTemplate system, token invalidation on use, rate-limit per email.


### PR DESCRIPTION
Closes #142.

**What you can now do:** create a custom role from the roles page, tick permissions in a grouped picker (per-resource wildcards plus global full access), edit and delete custom roles. System roles show as locked, with the reason: they're managed in code and re-synced on every boot. The picker is fed by the catalogue endpoint, so once #140 merges the wms permissions appear in it with no further work.

**Backend fixes found while in there:**
- No role route had a permission guard. Any authenticated user could create a role with `*` and assign it to themselves. All routes now need `roles:read` (reads) or `roles:write` (mutations, assignment, seed).
- Editing a system role used to succeed and then silently revert on next boot. It's now refused with a clear error.
- Another `organization.findFirst()` helper removed (unused).

Tests: 6 route tests covering the guard matrix and the system-role refusal. Frontend and backend tsc clean, full suite 1667 green. Not verified in a browser; the page structure follows the existing dialog patterns and every field (name, description, permissions) is present in create, edit, and the card display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)